### PR TITLE
Properly pass redirect preferene to Typhoeus

### DIFF
--- a/lib/html/proofer/check.rb
+++ b/lib/html/proofer/check.rb
@@ -36,7 +36,7 @@ class HTML::Proofer::Checks
     end
 
     def validate_url(href, issue_text)
-      request = Typhoeus::Request.new(href, {:followlocation => true})
+      request = Typhoeus::Request.new(href, followlocation: true)
       request.on_complete do |response|
         if response.success?
           # no op


### PR DESCRIPTION
Per [the documentation](https://github.com/typhoeus/typhoeus#example), it should be `followlocation: true` not `:followlocation => true`.

Fixes #14 
