### PR TITLE
Replace 'return' with 'next' in block

### DIFF
--- a/lib/html/proofer/checks/links.rb
+++ b/lib/html/proofer/checks/links.rb
@@ -20,10 +20,16 @@ class Links < ::HTML::Proofer::Checks::Check
       next if link.ignore?
 
       # is there even a href?
-      return self.add_issue("link has no href attribute") if link.missing_href?
+      if link.missing_href?
+        self.add_issue("link has no href attribute")
+        next
+      end
 
       # is it even a valid URL?
-      return self.add_issue "#{link.href} is an invalid URL" unless link.valid?
+      unless link.valid?
+        self.add_issue "#{link.href} is an invalid URL"
+        next
+      end
 
       # does the file even exist?
       if link.remote?


### PR DESCRIPTION
Fixes a pretty nasty logic error that prevents HTML::Proofer from checking any links in a file once it finds one that should be ignored.
## To Do
- [ ] Write test(s) to prevent future regressions
