### PR TITLE
Tell Mercenary to read in --swap and --ignore as arrays

### DIFF
--- a/bin/htmlproof
+++ b/bin/htmlproof
@@ -15,8 +15,8 @@ Mercenary.program(:htmlproof) do |p|
   p.description "Runs the HTML-Proofer suite on the files in PATH"
 
   p.option 'ext', '--ext EXT', 'The extension of your HTML files (default: `.html`)'
-  p.option 'swap', '--swap regex:string,[regex:string,...]', 'Array containing key-value pairs of `RegExp:String`. It transforms links that match `RegExp` into `String`'
-  p.option 'ignore', '--ignore link1,[link2,...]', 'Array of Strings containing `href`s that are safe to ignore (default: `mailto`)'
+  p.option 'swap', '--swap regex:string,[regex:string,...]', Array, 'Array containing key-value pairs of `RegExp:String`. It transforms links that match `RegExp` into `String`'
+  p.option 'ignore', '--ignore link1,[link2,...]', Array, 'Array of Strings containing `href`s that are safe to ignore (default: `mailto`)'
   p.option 'disable_external', '--disable_external', 'Disables the external link checker (default: `false`)'
 
   p.action do |args, opts|


### PR DESCRIPTION
Fixes this problem:

``` test
+ htmlproof _site/ --ignore faz.net
Running [Links, Images] checks on _site/ on *.html...

htmlproof 0.6.7 | Error:  undefined method `each' for "faz.net":String
```
