### PR TITLE
Add HTML::Proofer#failed_tests

### DIFF
--- a/lib/html/proofer.rb
+++ b/lib/html/proofer.rb
@@ -8,6 +8,8 @@ module HTML
   class Proofer
     include Yell::Loggable
 
+    attr_accessor :failed_tests
+
     def initialize(src, opts={})
       @srcDir = src
 

--- a/spec/html/proofer_spec.rb
+++ b/spec/html/proofer_spec.rb
@@ -1,0 +1,12 @@
+require "spec_helper"
+
+describe HTML::Proofer do
+  describe "#failed_tests" do
+    it "is a list of the formatted errors" do
+      brokenLinkInternalFilepath = "#{FIXTURES_DIR}/brokenLinkInternal.html"
+      proofer = HTML::Proofer.new(brokenLinkInternalFilepath)
+      capture_stderr { proofer.run }
+      proofer.failed_tests.should eq(["\e[34mspec/html/proofer/fixtures/brokenLinkInternal.html\e[0m: internally linking to ./notreal.html, which does not exist"])
+    end
+  end
+end


### PR DESCRIPTION
This is a selfish PR in that it would make retrieving errors by external modules easier (see https://github.com/afeld/markdown_proofer/pull/8), but I do think some refactoring could be done to clean up the code around passing errors and checking them in the specs.  :baby: step :wink: 
