### PR TITLE
Sort issues

### DIFF
--- a/lib/html/proofer.rb
+++ b/lib/html/proofer.rb
@@ -74,7 +74,7 @@ module HTML
       if @failed_tests.empty?
         logger.info "HTML-Proofer finished successfully.".green
       else
-        @failed_tests.each do |issue|
+        @failed_tests.sort.each do |issue|
           logger.error (issue + "\n\n").red
         end
 


### PR DESCRIPTION
Now external issues come out in random order:

``` bash
#0
_site/docs/history/index.html: External link https://github.com/bahuvrihi failed: 404 No error
#0
_site/docs/history/index.html: External link https://github.com/gcnovus failed: 404 No error
#1
_site/docs/deployment-methods/index.html: External link https://github.com/rtomakyo/shotgun/ failed: 404 No error
#2
_site/docs/extras/index.html: External link http://kramdown.rubyforge.org/ failed: got a time out
#1
_site/docs/deployment-methods/index.html: External link http://net-ssh.rubyforge.org/ failed: got a time out
#3
_site/docs/plugins/index.html: External link http://ultraviolet.rubyforge.org/ failed: got a time out
#2
_site/docs/extras/index.html: External link http://kramdown.rubyforge.org/options.html failed: got a time out
#3
_site/docs/plugins/index.html: External link http://saswatpadhi.github.io/ failed: 404 No error
```

Sorted issues would support the cleaning workflow. It’s handy.
