### PR TITLE
Some more cosemtic changes

### DIFF
--- a/html-proofer.gemspec
+++ b/html-proofer.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency "mercenary",       "~> 0.3.2"
-  gem.add_dependency "nokogiri",        "~> 1.6.0"
+  gem.add_dependency "nokogiri",        "~> 1.5"
   gem.add_dependency "colored",         "~> 1.2"
   gem.add_dependency "typhoeus",        "~> 0.6.7"
   gem.add_dependency "yell",            "~> 2.0"


### PR DESCRIPTION
GitHub.com the website would like to use html-proofer for link UI and mailers. There's a dependency problem though:

```
Bundler could not find compatible versions for gem "nokogiri":
  In Gemfile:
    html-proofer depends on
      nokogiri (~> 1.6.0)

    gollum depends on
      nokogiri (1.5.11)
```

Let's fix that. 
