### PR TITLE
Don't colorize failed tests unless printing to a TTY

### DIFF
--- a/lib/html/proofer.rb
+++ b/lib/html/proofer.rb
@@ -65,7 +65,7 @@ module HTML
         logger.info colorize :green, "HTML-Proofer finished successfully."
       else
         @failed_tests.sort.each do |issue|
-          logger.error issue.to_s.red
+          logger.error colorize :red, issue.to_s
         end
 
         raise colorize :red, "HTML-Proofer found #{@failed_tests.length} failures!"


### PR DESCRIPTION
I missed this in 1c7ffac828fb0e5a5f4280e0d45b2c6f6ff94106.
