### PR TITLE
Run specs in a random order

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,9 @@ RSpec.configure do |config|
 
   # Use the specified formatter
   config.formatter = :documentation # :progress, :html, :textmate
+
+  # Run in a random order
+  config.order = :random
 end
 
 def capture_stderr(&block)


### PR DESCRIPTION
Make sure the tests are not order dependent.
