### PR TITLE
Remove version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ If you generate HTML files, _then this tool might be for you_.
 
 `HTML::Proofer` is a set of tests to validate your HTML output. These tests check if your image references are legitimate, if they have alt tags, if your internal links are working, and so on. It's intended to be an all-in-one checker for your output.
 
-[![Build Status](https://travis-ci.org/gjtorikian/html-proofer.svg?branch=master)](https://travis-ci.org/gjtorikian/html-proofer) [![Gem Version](https://badge.fury.io/rb/html-proofer.svg)](http://badge.fury.io/rb/html-proofer)
+[![Build Status](https://travis-ci.org/gjtorikian/html-proofer.svg?branch=master)](https://travis-ci.org/gjtorikian/html-proofer)
 
 ## Installation
 


### PR DESCRIPTION
I don’t understand the use of the version badge. Moreover the link is [not reliable](https://travis-ci.org/gjtorikian/html-proofer/jobs/33724806).
