### PR TITLE
Cache the Uri parser instance in Checkable, results in a 14x performance increase

### DIFF
--- a/lib/html/proofer/checkable.rb
+++ b/lib/html/proofer/checkable.rb
@@ -36,9 +36,11 @@ module HTML
       end
 
       def parts
-        URI::Parser.new(:ESCAPED => '\%|\|').parse url
+        return @parts_cached if defined?(@parts_cached)
+
+        @parts_cached = URI::Parser.new(:ESCAPED => '\%|\|').parse url
       rescue URI::Error
-        nil
+        @parts_cached = nil
       end
 
       def path


### PR DESCRIPTION
The parts getter in Checkable is called **very** often, which means caching the Uri parser instance instead of recreating it on every call massively improves performance.

Here's a small timing of a site with ~30 files (external checks ignored):

| before | after |
| --- | --- |
| **real 0m25.782s** | **real 0m1.810s** |
| user 0m25.377s | user 0m1.681s |
| sys 0m0.384s | sys 0m0.122s |
