### PR TITLE
Process files in parallel to improve performance

### DIFF
--- a/html-proofer.gemspec
+++ b/html-proofer.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "colored",         "~> 1.2"
   gem.add_dependency "typhoeus",        "~> 0.6.7"
   gem.add_dependency "yell",            "~> 2.0"
+  gem.add_dependency "parallel",        "~> 1.3"
 
   gem.add_development_dependency "redcarpet"
   gem.add_development_dependency "rspec", "~> 2.13.0"


### PR DESCRIPTION
Not sure if you want to take it, but this improved performance for me as well (i.e. it now saturates all my four cores instead of only one).

Sample improvement for our [website](https://github.com/mono/website) (both timings with PR #112 applied) on my four core machine:

| before | after |
| --- | --- |
| **real 1m26.940s** | **real 0m25.262s** |
| user 1m24.883s | user 1m28.469s |
| sys 0m1.166s | sys 0m2.610s |
