### PR TITLE
Don't use deprecated method

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ require 'html/pipeline'
 require 'find'
 
 # make an out dir
-Dir.mkdir("out") unless File.exists?("out")
+Dir.mkdir("out") unless File.exist?("out")
 
 pipeline = HTML::Pipeline.new [
   HTML::Pipeline::MarkdownFilter,


### PR DESCRIPTION
The following warning occurred in the script in README.md:

    % ruby -v -W -e 'Dir.mkdir("out") unless File.exists?("out")'
    ruby 2.1.5p273 (2014-11-13 revision 48405) [x86_64-linux]
    -e:1: warning: File.exists? is a deprecated name, use File.exist? instead

I tried not to use a deprecated method.