### PR TITLE
Proper iteration over multiple file ignores

### DIFF
--- a/lib/html/proofer.rb
+++ b/lib/html/proofer.rb
@@ -136,12 +136,9 @@ module HTML
     end
 
     def ignore_file?(file)
-      @options[:file_ignore].each do |pattern|
-        if pattern.is_a? String
-          return pattern == file
-        elsif pattern.is_a? Regexp
-          return pattern =~ file
-        end
+      while (pattern = @options[:file_ignore].pop)
+        return pattern == file if pattern.is_a? String
+        return pattern =~ file if pattern.is_a? Regexp
       end
 
       false

--- a/lib/html/proofer.rb
+++ b/lib/html/proofer.rb
@@ -136,7 +136,8 @@ module HTML
     end
 
     def ignore_file?(file)
-      while (pattern = @options[:file_ignore].pop)
+      patterns = @options[:file_ignore].dup
+      while (pattern = patterns.pop)
         return pattern == file if pattern.is_a? String
         return pattern =~ file if pattern.is_a? Regexp
       end

--- a/lib/html/proofer.rb
+++ b/lib/html/proofer.rb
@@ -136,10 +136,9 @@ module HTML
     end
 
     def ignore_file?(file)
-      patterns = @options[:file_ignore].dup
-      while (pattern = patterns.pop)
-        return pattern == file if pattern.is_a? String
-        return pattern =~ file if pattern.is_a? Regexp
+      options[:file_ignore].each do |pattern|
+        return true if pattern.is_a?(String) && pattern == file
+        return true if pattern.is_a?(Regexp) && pattern =~ file
       end
 
       false

--- a/spec/html/proofer/fixtures/links/folder/multiples/catalog/file.html
+++ b/spec/html/proofer/fixtures/links/folder/multiples/catalog/file.html
@@ -1,0 +1,8 @@
+<html>
+
+<body>
+
+<a href="http://www.asdo3IRJ395295jsingrkrg4.com">broken link!</a>
+</body>
+
+</html>

--- a/spec/html/proofer/fixtures/links/folder/multiples/javadoc/file.html
+++ b/spec/html/proofer/fixtures/links/folder/multiples/javadoc/file.html
@@ -1,0 +1,8 @@
+<html>
+
+<body>
+
+<a href="http://www.asdo3IRJ395295jsingrkrg4.com">broken link!</a>
+</body>
+
+</html>

--- a/spec/html/proofer_spec.rb
+++ b/spec/html/proofer_spec.rb
@@ -90,6 +90,13 @@ describe HTML::Proofer do
         expect(proofer.failed_tests).to eq []
       end
 
+      it 'knows how to ignore multiple files by regexp' do
+        options = { :file_ignore => [%r{.*/javadoc/.*}, %r{.*/catalog/.*}] }
+        brokenFolders = "#{FIXTURES_DIR}/links/folder/multiples"
+        proofer = run_proofer(brokenFolders, options)
+        expect(proofer.failed_tests).to eq []
+      end
+
       it 'knows how to ignore a directory by regexp' do
         options = { :file_ignore => [/\S\.html/] }
         linksDir = "#{FIXTURES_DIR}/links"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,13 +21,13 @@ def capture_stderr(*)
   original_stderr = $stderr
   original_stdout = $stdout
   $stderr = fake_err = StringIO.new
-  $stdout = fake_out = StringIO.new
+  # $stdout = fake_out = StringIO.new
   begin
     yield
   rescue RuntimeError
   ensure
     $stderr = original_stderr
-    $stdout = original_stdout
+    # $stdout = original_stdout
   end
   fake_err.string
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,13 +21,13 @@ def capture_stderr(*)
   original_stderr = $stderr
   original_stdout = $stdout
   $stderr = fake_err = StringIO.new
-  # $stdout = fake_out = StringIO.new
+  $stdout = fake_out = StringIO.new
   begin
     yield
   rescue RuntimeError
   ensure
     $stderr = original_stderr
-    # $stdout = original_stdout
+    $stdout = original_stdout
   end
   fake_err.string
 end


### PR DESCRIPTION
Fixes https://github.com/gjtorikian/html-proofer/issues/145.

~~Not sure why `each` didn't work in this case. Very strange.~~ A premature `return` was causing the `each` loop to short circuit. Sneaky!