### PR TITLE
Add missing cgi dependency

### DIFF
--- a/lib/html/proofer/checkable.rb
+++ b/lib/html/proofer/checkable.rb
@@ -1,4 +1,5 @@
 require 'addressable/uri'
+require 'cgi'
 require_relative './utils'
 
 module HTML


### PR DESCRIPTION
`htmlproof --check-html` tries to call CGI.unescape, which is not in scope
at the moment.