### PR TITLE
perform url substitutions in src attributes also

### DIFF
--- a/lib/html/proofer/checkable.rb
+++ b/lib/html/proofer/checkable.rb
@@ -22,7 +22,11 @@ module HTML
         if @href && @check.options[:href_swap]
           @href = swap(@href, @check.options[:href_swap])
         end
-
+        
+        if @src && @check.options[:href_swap]
+          @src = swap(@src, @check.options[:href_swap])
+        end
+        
         # fix up missing protocols
         @href.insert 0, 'http:' if @href =~ %r{^//}
         @src.insert 0, 'http:' if @src =~ %r{^//}

--- a/spec/html/proofer/fixtures/images/replaceAbsUrlSrc.html
+++ b/spec/html/proofer/fixtures/images/replaceAbsUrlSrc.html
@@ -1,0 +1,2 @@
+
+<img alt="sure thing" src="http://baseurl.com/gpl.png"/> base url is relative to root

--- a/spec/html/proofer/fixtures/images/replaceAbsUrlSrc.html
+++ b/spec/html/proofer/fixtures/images/replaceAbsUrlSrc.html
@@ -1,2 +1,2 @@
 
-<img alt="sure thing" src="http://baseurl.com/gpl.png"/> base url is relative to root
+<img alt="sure thing" src="http://baseurl.com/gpl.png"/>

--- a/spec/html/proofer/fixtures/scripts/script_abs_url.html
+++ b/spec/html/proofer/fixtures/scripts/script_abs_url.html
@@ -1,0 +1,9 @@
+<html>
+
+<body>
+
+  <script src="http://baseurl.com/script.js"></script>
+
+</body>
+
+</html>

--- a/spec/html/proofer/fixtures/scripts/script_abs_url.html
+++ b/spec/html/proofer/fixtures/scripts/script_abs_url.html
@@ -2,7 +2,7 @@
 
 <body>
 
-  <script src="http://baseurl.com/script.js"></script>
+  <script src="http://example.com/script.js"></script>
 
 </body>
 

--- a/spec/html/proofer/images_spec.rb
+++ b/spec/html/proofer/images_spec.rb
@@ -122,7 +122,7 @@ describe 'Images test' do
 
   it 'translates src via href_swap' do
     translatedSrc = "#{FIXTURES_DIR}/images/replaceAbsUrlSrc.html"
-    proofer = run_proofer(translatedSrc, { :href_swap => { %r{^http://baseurl.com} => "" } })
+    proofer = run_proofer(translatedSrc, { :href_swap => { %r{^http://example.com} => "" } })
     expect(proofer.failed_tests).to eq []
   end
 end

--- a/spec/html/proofer/images_spec.rb
+++ b/spec/html/proofer/images_spec.rb
@@ -119,4 +119,10 @@ describe 'Images test' do
     proofer = run_proofer(ignorableLinks, {:alt_ignore => [/wikimedia/, "gpl.png"]})
     expect(proofer.failed_tests).to eq []
   end
+
+  it 'translates src via href_swap' do
+    translatedSrc = "#{FIXTURES_DIR}/images/replaceAbsUrlSrc.html"
+    proofer = run_proofer(translatedSrc, { :href_swap => { %r{^http://baseurl.com} => "" } })
+    expect(proofer.failed_tests).to eq []
+  end
 end

--- a/spec/html/proofer/scripts_spec.rb
+++ b/spec/html/proofer/scripts_spec.rb
@@ -40,7 +40,7 @@ describe 'Scripts test' do
 
   it 'translates src via href_swap' do
     file = "#{FIXTURES_DIR}/scripts/script_abs_url.html"
-    proofer = run_proofer(file, { :href_swap => { %r{^http://baseurl.com} => "" } })
+    proofer = run_proofer(file, { :href_swap => { %r{^http://example.com} => "" } })
     expect(proofer.failed_tests).to eq []
   end
 end

--- a/spec/html/proofer/scripts_spec.rb
+++ b/spec/html/proofer/scripts_spec.rb
@@ -38,4 +38,9 @@ describe 'Scripts test' do
     expect(proofer.failed_tests).to eq []
   end
 
+  it 'translates src via href_swap' do
+    file = "#{FIXTURES_DIR}/scripts/script_abs_url.html"
+    proofer = run_proofer(file, { :href_swap => { %r{^http://baseurl.com} => "" } })
+    expect(proofer.failed_tests).to eq []
+  end
 end


### PR DESCRIPTION
Static site generators have the option of generating urls with a baked-in base url. When using this type of option, links have absolute urls which will not resolve when checking locally. When performing checks against a static site on local filesystem the href_swap option can be used to properly check these links. Example content:
```html
...
<link href="http://baseurl.com/index.xml" rel="alternate" type="application/rss+xml" title="Website Title RSS" />
...
<a href="http://baseurl.com/license">lic</a>
...
<script src="http://baseurl.com/js/jquery.min.js"></script>
...
```

Link check will fail with vanilla htmlproof config, but using the following config will work for the hrefs:
```{:href_swap => {/http:\/\/baseurl\.com/ => ""} ```

The script tag will still fail however.  This pr adds the same regex substition to the src attributes.