### PR TITLE
Do a better job reporting failed attributes

### DIFF
--- a/lib/html/proofer/checks/favicon.rb
+++ b/lib/html/proofer/checks/favicon.rb
@@ -9,8 +9,13 @@ end
 class FaviconCheck < ::HTML::Proofer::CheckRunner
 
   def run
-    @html.xpath('//link[not(ancestor::pre or ancestor::code)]').each do |favicon|
-      favicon = FaviconCheckable.new favicon, self
+    @html.xpath('//link[not(ancestor::pre or ancestor::code)]').each do |f|
+      begin
+        favicon = FaviconCheckable.new f, self
+      rescue NameError => e
+        next add_issue(e, f.line)
+      end
+
       next if favicon.ignore?
       return if favicon.rel.split(' ').last.eql? 'icon'
     end

--- a/lib/html/proofer/checks/images.rb
+++ b/lib/html/proofer/checks/images.rb
@@ -25,7 +25,11 @@ end
 class ImageCheck < ::HTML::Proofer::CheckRunner
   def run
     @html.css('img').each do |i|
-      img = ImageCheckable.new i, self
+      begin
+        img = ImageCheckable.new i, self
+      rescue NameError => e
+        next add_issue(e, i.line)
+      end
 
       next if img.ignore?
 

--- a/lib/html/proofer/checks/links.rb
+++ b/lib/html/proofer/checks/links.rb
@@ -28,7 +28,11 @@ class LinkCheck < ::HTML::Proofer::CheckRunner
 
   def run
     @html.css('a, link').each do |l|
-      link = LinkCheckable.new l, self
+      begin
+        link = LinkCheckable.new l, self
+      rescue NameError => e
+        next add_issue(e, l.line)
+      end
 
       next if link.ignore?
       next if link.href =~ /^javascript:/ # can't put this in ignore? because the URI does not parse

--- a/spec/html/proofer/fixtures/utils/broken_attribute.html
+++ b/spec/html/proofer/fixtures/utils/broken_attribute.html
@@ -1,0 +1,3 @@
+<a xmlns:cc="http://creativecommons.org/ns#" href="http://woss.name/" property="cc:attributionName" rel="cc:attributionURL”>
+  Graeme Mathieson
+</a>

--- a/spec/html/proofer_spec.rb
+++ b/spec/html/proofer_spec.rb
@@ -119,4 +119,12 @@ describe HTML::Proofer do
       expect(proofer.checks.length).to eq 3
     end
   end
+
+  describe 'failed ivar attributes' do
+    it 'provides some actual help' do
+      brokenAttribute = "#{FIXTURES_DIR}/utils/broken_attribute.html"
+      proofer = run_proofer(brokenAttribute)
+      expect(proofer.failed_tests.first).to match(/@xmlns:cc' is not allowed as an instance variable name \(line 4\)/)
+    end
+  end
 end


### PR DESCRIPTION
Will close https://github.com/gjtorikian/html-proofer/issues/173.

If for some reason we cannot create a checker object--looks like if you have zany or broken attributes, this can be the case--we will report it as a failure. 

Perhaps there should be an option to toggle this off. For example, if you have `xmlns:whatever`, as @mathie experienced, we will just not create an attribute on the object, and we won't report the error, either. @penibelst what do you think?