### PR TITLE
only split into two

### DIFF
--- a/bin/htmlproof
+++ b/bin/htmlproof
@@ -56,7 +56,7 @@ Mercenary.program(:htmlproof) do |p|
     unless opts['href_swap'].nil?
       options[:href_swap] = {}
       opts['href_swap'].each do |s|
-        pair = s.split(':')
+        pair = s.split(':', 2)
         options[:href_swap][Regexp.new(pair[0])] = pair[1]
       end
     end


### PR DESCRIPTION
this avoids the problem when there's more than one colon in the string, to split it into more pieces

around the same code, there is a situation when the string is surrounded by // that needs to be solved
it is converted into a regular expression, and then the split method is not available and the application breaks.

thank you