### PR TITLE
Add --ignore-empty-alt option

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ The `HTML::Proofer` constructor takes an optional hash of additional options:
 | Option | Description | Default |
 | :----- | :---------- | :------ |
 | `alt_ignore` | An array of Strings or RegExps containing `img`s whose missing `alt` tags are safe to ignore. | `[]` |
+| `alt_empty_igore` | If `true`, don't complain about images with empty alt tags. | `false` |
 | `check_external_hash` | Checks whether external hashes exist (even if the website exists). This slows the checker down. | `false` |
 |`checks_to_ignore`| An array of Strings indicating which checks you'd like to not perform. | `[]`
 | `directory_index_file` | Sets the file to look for when a link refers to a directory. | `index.html` |

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ The `HTML::Proofer` constructor takes an optional hash of additional options:
 | Option | Description | Default |
 | :----- | :---------- | :------ |
 | `alt_ignore` | An array of Strings or RegExps containing `img`s whose missing `alt` tags are safe to ignore. | `[]` |
-| `alt_empty_igore` | If `true`, don't complain about images with empty alt tags. | `false` |
+| `alt_empty_ignore` | If `true`, don't complain about images with empty alt tags. | `false` |
 | `check_external_hash` | Checks whether external hashes exist (even if the website exists). This slows the checker down. | `false` |
 |`checks_to_ignore`| An array of Strings indicating which checks you'd like to not perform. | `[]`
 | `directory_index_file` | Sets the file to look for when a link refers to a directory. | `index.html` |

--- a/bin/htmlproof
+++ b/bin/htmlproof
@@ -24,6 +24,7 @@ Mercenary.program(:htmlproof) do |p|
 
   p.option 'as_links', '--as-links', 'Assumes that `PATH` is a comma-separated array of links to check.'
   p.option 'alt_ignore', '--alt-ignore image1,[image2,...]', Array, 'Comma-separated list of Strings or RegExps containing `img`s whose missing `alt` tags are safe to ignore'
+  p.option 'alt_empty_ignore', '--alt-empty-ignore', 'Don\'t complain about images with empty alt tags.'
   p.option 'checks_to_ignore', '--checks-to-ignore check1,[check2,...]', Array, ' An array of Strings indicating which checks you\'d like to not perform.'
   p.option 'check_external_hash', '--check-external-hash', 'Checks whether external hashes exist (even if the website exists). This slows the checker down (default: `false`).'
   p.option 'directory_index_file', '--directory-index-file', String, 'Sets the file to look for when a link refers to a directory. (default: `index.html`)'

--- a/lib/html/proofer.rb
+++ b/lib/html/proofer.rb
@@ -34,6 +34,7 @@ module HTML
         :file_ignore => [],
         :check_external_hash => false,
         :alt_ignore => [],
+        :alt_empty_ignore => false,
         :disable_external => false,
         :verbose => false,
         :only_4xx => false,

--- a/lib/html/proofer/check_runner.rb
+++ b/lib/html/proofer/check_runner.rb
@@ -6,7 +6,7 @@ module HTML
     class CheckRunner
 
       attr_reader :issues, :src, :path, :options, :typhoeus_opts, :hydra_opts, :parallel_opts, \
-                  :external_urls, :href_ignores, :alt_ignores
+                  :external_urls, :href_ignores, :alt_ignores, :alt_empty_ignore
 
       def initialize(src, path, html, options, typhoeus_opts, hydra_opts, parallel_opts)
         @src    = src
@@ -19,6 +19,7 @@ module HTML
         @issues = []
         @href_ignores = @options[:href_ignore]
         @alt_ignores = @options[:alt_ignore]
+        @alt_empty_ignore = @options[:alt_empty_ignore]
         @external_urls = {}
       end
 

--- a/lib/html/proofer/checkable.rb
+++ b/lib/html/proofer/checkable.rb
@@ -77,6 +77,10 @@ module HTML
         end
       end
 
+      def alt_empty_ignore?
+        return true if @check.alt_empty_ignore
+      end
+
       # path is external to the file
       def external?
         !internal?

--- a/lib/html/proofer/checks/images.rb
+++ b/lib/html/proofer/checks/images.rb
@@ -4,8 +4,12 @@ class ImageCheckable < ::HTML::Proofer::Checkable
 
   SCREEN_SHOT_REGEX = /Screen(?: |%20)Shot(?: |%20)\d+-\d+-\d+(?: |%20)at(?: |%20)\d+.\d+.\d+/
 
-  def valid_alt_tag?
-    @alt && !@alt.empty?
+  def has_alt_tag?
+    @alt
+  end
+
+  def empty_alt_tag?
+    @alt.empty?
   end
 
   def terrible_filename?
@@ -44,7 +48,9 @@ class ImageCheck < ::HTML::Proofer::CheckRunner
       end
 
       # check alt tag
-      add_issue("image #{img.src} does not have an alt attribute", i.line) unless img.valid_alt_tag?
+      if !img.has_alt_tag? || (img.empty_alt_tag? && !img.alt_empty_ignore?)
+        add_issue("image #{img.src} does not have an alt attribute", i.line)
+      end
     end
 
     external_urls

--- a/spec/html/proofer/images_spec.rb
+++ b/spec/html/proofer/images_spec.rb
@@ -96,6 +96,18 @@ describe 'Images test' do
     expect(proofer.failed_tests.first).to_not match /does not have an alt attribute/
   end
 
+  it 'properly ignores empty alt attribute when alt_empty_ignore set' do
+    missingAltFilepath = "#{FIXTURES_DIR}/images/missingImageAltText.html"
+    proofer = run_proofer(missingAltFilepath, {:alt_empty_ignore => true})
+    expect(proofer.failed_tests).to eq []
+  end
+
+  it 'properly ignores empty alt attributes, but not missing alt attributes, when alt_empty_ignore set' do
+    missingAltFilepath = "#{FIXTURES_DIR}/images/missingImageAlt.html"
+    proofer = run_proofer(missingAltFilepath, {:alt_empty_ignore => true})
+    expect(proofer.failed_tests.first).to match(/gpl.png does not have an alt attribute/)
+  end
+
   it 'works for images with a srcset' do
     srcSetCheck = "#{FIXTURES_DIR}/images/srcSetCheck.html"
     proofer = run_proofer(srcSetCheck)


### PR DESCRIPTION
I'm trying to use `htmlproofer` on a documentation site with a lot of screenshots. The screenshots don't have any information that's missing from the text, so they all have `alt=""` set. Unfortunately this causes htmlproofer to complain "`image [...] does not have an alt attribute`".
#39 raised this problem, but resolved it with the `alt_ignore` option; I don't want to have to update the list every time I write more documentation.

This code is probably terrible; I don't know Ruby very well.