### PR TITLE
Set default user agent

### DIFF
--- a/lib/html/proofer.rb
+++ b/lib/html/proofer.rb
@@ -44,7 +44,10 @@ module HTML
       }
 
       @typhoeus_opts = opts[:typhoeus] || {
-        :followlocation => true
+        :followlocation => true,
+        :headers => {
+          "User-Agent" => "Mozilla/5.0 (compatible; HTML Proofer/#{VERSION}; +https://github.com/gjtorikian/html-proofer)"
+        }
       }
       opts.delete(:typhoeus)
 


### PR DESCRIPTION
This pull request sets the default user agent as `Mozilla/5.0 (compatible; HTML Proofer/2.1.0}; +https://github.com/gjtorikian/html-proofer)`. The user agent screen is based off of GoogleBot's user agent format. This should allow us to bypass Typhoeus-specific blocks on WordPress and Drupal.

Via @gjtorikian over in https://github.com/gjtorikian/html-proofer/issues/200#issuecomment-94313702:

> What are the ethics involved in my changing the User-Agent to something non-static to avoid being blacklisted again?

I believe as long as we're honest, and identify as HTML-Proofer (which can be blocked if that is in fact the desired behavior), we're fine. I don't think we should e.g., have a random string as a user agent hash. I suspect the services are blocking Typhoeus to prevent scraping, which is not what we're doing here.

Fixes https://github.com/gjtorikian/html-proofer/issues/197. Fixes https://github.com/gjtorikian/html-proofer/issues/200.
 