### PR TITLE
Faster Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,6 @@ env:
 addons:
   code_climate:
     repo_token:
+
+sudo: false
+cache: bundler


### PR DESCRIPTION
* Use the container-based infra which usually has a shorter queue 
* Cache gems between builds