### PR TITLE
Better Typhoeus option handling

### DIFF
--- a/lib/html/proofer.rb
+++ b/lib/html/proofer.rb
@@ -23,6 +23,13 @@ module HTML
 
     attr_reader :options, :typhoeus_opts, :hydra_opts, :parallel_opts
 
+    TYPHOEUS_DEFAULTS = {
+      :followlocation => true,
+      :headers => {
+        "User-Agent" => "Mozilla/5.0 (compatible; HTML Proofer/#{VERSION}; +https://github.com/gjtorikian/html-proofer)"
+      }
+    }
+
     def initialize(src, opts = {})
       @src = src
 
@@ -43,12 +50,7 @@ module HTML
         :checks_to_ignore => []
       }
 
-      @typhoeus_opts = opts[:typhoeus] || {
-        :followlocation => true,
-        :headers => {
-          "User-Agent" => "Mozilla/5.0 (compatible; HTML Proofer/#{VERSION}; +https://github.com/gjtorikian/html-proofer)"
-        }
-      }
+      @typhoeus_opts = TYPHOEUS_DEFAULTS.merge(opts[:typhoeus] || {})
       opts.delete(:typhoeus)
 
       @hydra_opts = opts[:hydra] || {}

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+bundle install "$@"


### PR DESCRIPTION
@benbalter Ugh so dumb. Since [the test](https://github.com/gjtorikian/html-proofer/blob/14edbcaaee5dc078f1d4c7ae938e553174741ba7/spec/html/proofer/links_spec.rb#L79-L83) was passing in its own Typhoeus options, it overwrote the User-Agent option. 

This PR changes things to keep the UA change while still respect other key changes.

Closes https://github.com/gjtorikian/html-proofer/issues/200.