### PR TITLE
Strip whitespace from empty `alt` tags

### DIFF
--- a/lib/html/proofer/checks/images.rb
+++ b/lib/html/proofer/checks/images.rb
@@ -5,7 +5,7 @@ class ImageCheckable < ::HTML::Proofer::Checkable
   SCREEN_SHOT_REGEX = /Screen(?: |%20)Shot(?: |%20)\d+-\d+-\d+(?: |%20)at(?: |%20)\d+.\d+.\d+/
 
   def valid_alt_tag?
-    @alt && !@alt.empty?
+    @alt && !@alt.strip.empty?
   end
 
   def terrible_filename?

--- a/spec/html/proofer/fixtures/images/emptyImageAltText.html
+++ b/spec/html/proofer/fixtures/images/emptyImageAltText.html
@@ -1,0 +1,9 @@
+<html>
+
+<body>
+
+	<p>Blah blah blah. <img src="./gpl.png" alt=""/> </p>
+  	<p>Blah blah blah. <img src="./gpl.png" alt="   "/> </p>
+</body>
+
+</html>

--- a/spec/html/proofer/images_spec.rb
+++ b/spec/html/proofer/images_spec.rb
@@ -19,6 +19,19 @@ describe 'Images test' do
     expect(proofer.failed_tests.first).to match(/gpl.png does not have an alt attribute/)
   end
 
+  it 'fails for image with nothing but spaces in alt attribute' do
+    emptyAltFilepath = "#{FIXTURES_DIR}/images/emptyImageAltText.html"
+    proofer = run_proofer(emptyAltFilepath)
+    expect(proofer.failed_tests.first).to match(/gpl.png does not have an alt attribute/)
+    expect(proofer.failed_tests.length).to equal(2)
+  end
+
+  it 'passes when ignoring image with nothing but spaces in alt attribute' do
+    emptyAltFilepath = "#{FIXTURES_DIR}/images/emptyImageAltText.html"
+    proofer = run_proofer(emptyAltFilepath, {:alt_ignore => [/.+/]})
+    expect(proofer.failed_tests).to eq []
+  end
+
   it 'fails for missing external images' do
     externalImageFilepath = "#{FIXTURES_DIR}/images/missingImageExternal.html"
     proofer = run_proofer(externalImageFilepath)


### PR DESCRIPTION
This better handles a malicious `alt="    "` case.