### PR TITLE
Make href_ignore work on all elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ The `HTML::Proofer` constructor takes an optional hash of additional options:
 | `href_ignore` | An array of Strings or RegExps containing `href`s that are safe to ignore. Note that non-HTTP(S) URIs are always ignored. | `[]` |
 | `href_swap` | A hash containing key-value pairs of `RegExp => String`. It transforms links that match `RegExp` into `String` via `gsub`. | `{}` |
 | `only_4xx` | Only reports errors for links that fall within the 4xx status code range. | `false` |
+| `url_ignore` | An array of Strings or RegExps containing URLs that are safe to ignore. It affects all HTML attributes. Note that non-HTTP(S) URIs are always ignored. | `[]` |
 | `check_favicon` | Enables the favicon checker. | `false` |
 | `check_html` | Enables HTML validation errors from Nokogiri | `false` |
 | `verbose` | If `true`, outputs extra information as the checking happens. Useful for debugging. | `false` |

--- a/lib/html/proofer.rb
+++ b/lib/html/proofer.rb
@@ -39,6 +39,7 @@ module HTML
         :href_swap => [],
         :href_ignore => [],
         :file_ignore => [],
+        :url_ignore => [],
         :check_external_hash => false,
         :alt_ignore => [],
         :empty_alt_ignore => false,

--- a/lib/html/proofer/check_runner.rb
+++ b/lib/html/proofer/check_runner.rb
@@ -6,7 +6,7 @@ module HTML
     class CheckRunner
 
       attr_reader :issues, :src, :path, :options, :typhoeus_opts, :hydra_opts, :parallel_opts, \
-                  :external_urls, :href_ignores, :alt_ignores, :empty_alt_ignore
+                  :external_urls, :href_ignores, :url_ignores, :alt_ignores, :empty_alt_ignore
 
       def initialize(src, path, html, options, typhoeus_opts, hydra_opts, parallel_opts)
         @src    = src
@@ -18,6 +18,7 @@ module HTML
         @parallel_opts = parallel_opts
         @issues = []
         @href_ignores = @options[:href_ignore]
+        @url_ignores = @options[:url_ignore]
         @alt_ignores = @options[:alt_ignore]
         @empty_alt_ignore = @options[:empty_alt_ignore]
         @external_urls = {}

--- a/lib/html/proofer/checkable.rb
+++ b/lib/html/proofer/checkable.rb
@@ -134,8 +134,6 @@ module HTML
       end
 
       def ignores_pattern_check(links)
-        return false if links.nil?
-
         links.each do |ignore|
           if ignore.is_a? String
             return true if ignore == url

--- a/lib/html/proofer/checkable.rb
+++ b/lib/html/proofer/checkable.rb
@@ -72,14 +72,17 @@ module HTML
         end
 
         # ignore user defined URLs
-        return true if ignores_pattern_check(@check.href_ignores)
+        return true if ignores_pattern_check(@check.url_ignores)
+
+        # ignore user defined hrefs
+        if 'LinkCheckable' === @type
+          return true if ignores_pattern_check(@check.href_ignores)
+        end
 
         # ignore user defined alts
         if 'ImageCheckable' === @type
           return true if ignores_pattern_check(@check.alt_ignores)
         end
-
-        false
       end
 
       def ignore_empty_alt?
@@ -131,6 +134,8 @@ module HTML
       end
 
       def ignores_pattern_check(links)
+        return false if links.nil?
+
         links.each do |ignore|
           if ignore.is_a? String
             return true if ignore == url

--- a/lib/html/proofer/checkable.rb
+++ b/lib/html/proofer/checkable.rb
@@ -66,15 +66,20 @@ module HTML
       def ignore?
         return true if @data_proofer_ignore
 
-        case @type
-        when 'FaviconCheckable'
+        # ignore base64 encoded images
+        if %w(ImageCheckable FaviconCheckable).include? @type
           return true if url.match(/^data:image/)
-        when 'LinkCheckable'
-          return true if ignores_pattern_check(@check.href_ignores)
-        when 'ImageCheckable'
-          return true if url.match(/^data:image/)
+        end
+
+        # ignore user defined URLs
+        return true if ignores_pattern_check(@check.href_ignores)
+
+        # ignore user defined alts
+        if 'ImageCheckable' === @type
           return true if ignores_pattern_check(@check.alt_ignores)
         end
+
+        false
       end
 
       def ignore_empty_alt?

--- a/spec/html/proofer/checkable_spec.rb
+++ b/spec/html/proofer/checkable_spec.rb
@@ -8,4 +8,23 @@ describe HTML::Proofer::Checkable do
       expect(checkable.instance_variable_get(:@xmlns_cc)).to eq 'http://creativecommons.org/ns#'
     end
   end
+  describe '#ignores_pattern_check' do
+    it 'works for regex patterns' do
+      nokogiri = Nokogiri::HTML '<script src=/assets/main.js></script>'
+      checkable = HTML::Proofer::Checkable.new nokogiri.css('script').first, nil
+      expect(checkable.ignores_pattern_check([/\/assets\/.*(js|css|png|svg)/])).to eq true
+    end
+    it 'works for string patterns' do
+      nokogiri = Nokogiri::HTML '<script src=/assets/main.js></script>'
+      checkable = HTML::Proofer::Checkable.new nokogiri.css('script').first, nil
+      expect(checkable.ignores_pattern_check(['/assets/main.js'])).to eq true
+    end
+  end
+  describe '#url' do
+    it 'works for src attributes' do
+      nokogiri = Nokogiri::HTML '<img src=image.png />'
+      checkable = HTML::Proofer::Checkable.new nokogiri.css('img').first, nil
+      expect(checkable.url).to eq 'image.png'
+    end
+  end
 end

--- a/spec/html/proofer/fixtures/scripts/ignorableLinksViaOptions.html
+++ b/spec/html/proofer/fixtures/scripts/ignorableLinksViaOptions.html
@@ -1,0 +1,4 @@
+<html>
+<head>
+  <script src="/assets/main.js"></script>
+<body>

--- a/spec/html/proofer/scripts_spec.rb
+++ b/spec/html/proofer/scripts_spec.rb
@@ -38,9 +38,9 @@ describe 'Scripts test' do
     expect(proofer.failed_tests).to eq []
   end
 
-  it 'ignores links via href_ignore' do
+  it 'ignores links via url_ignore' do
     ignorableLinks = "#{FIXTURES_DIR}/scripts/ignorableLinksViaOptions.html"
-    proofer = run_proofer(ignorableLinks, { :href_ignore => [/\/assets\/.*(js|css|png|svg)/] })
+    proofer = run_proofer(ignorableLinks, { :url_ignore => [/\/assets\/.*(js|css|png|svg)/] })
     expect(proofer.failed_tests).to eq []
   end
 

--- a/spec/html/proofer/scripts_spec.rb
+++ b/spec/html/proofer/scripts_spec.rb
@@ -38,4 +38,10 @@ describe 'Scripts test' do
     expect(proofer.failed_tests).to eq []
   end
 
+  it 'ignores links via href_ignore' do
+    ignorableLinks = "#{FIXTURES_DIR}/scripts/ignorableLinksViaOptions.html"
+    proofer = run_proofer(ignorableLinks, { :href_ignore => [/\/assets\/.*(js|css|png|svg)/] })
+    expect(proofer.failed_tests).to eq []
+  end
+
 end


### PR DESCRIPTION
Fix #211 

From what I feel `href_ignore` should work on all checkable elements. I don’t think we want dedicated ignores for every possible attribute, like `src_ignore`, `srcset_ignore`, etc.