### PR TITLE
corrected code snippet missing curly bracket

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,5 +260,5 @@ To change the User-Agent used by Typhoeus:
 HTML::Proofer.new("out/", {
   :typhoeus => {
     :headers => { "User-Agent" => "Mozilla/5.0 (compatible; My New User-Agent" }
-}).run
+}}).run
 ```

--- a/README.md
+++ b/README.md
@@ -259,6 +259,6 @@ To change the User-Agent used by Typhoeus:
 ``` ruby
 HTML::Proofer.new("out/", {
   :typhoeus => {
-    :headers => { "User-Agent" => "Mozilla/5.0 (compatible; My New User-Agent" }
+    :headers => { "User-Agent" => "Mozilla/5.0 (compatible; My New User-Agent)" }
 }}).run
 ```


### PR DESCRIPTION
Code in the README with regards to changing the user agent is missing a closing curly bracket. 

Should read:

``` ruby
HTML::Proofer.new("out/", {
  :typhoeus => {
    :headers => { "User-Agent" => "Mozilla/5.0 (compatible; My New User-Agent" }
}}).run
```

Fix in pull request.