### PR TITLE
Accept the content attribute

### DIFF
--- a/lib/html/proofer/checkable.rb
+++ b/lib/html/proofer/checkable.rb
@@ -13,7 +13,7 @@ module HTML
           instance_variable_set("@#{attribute.tr('-:', '_')}".to_sym, value.value)
         end
 
-        @content = obj.content
+        @text = obj.content
         @check = check
         @checked_paths = {}
         @type = self.class.name

--- a/lib/html/proofer/checks/scripts.rb
+++ b/lib/html/proofer/checks/scripts.rb
@@ -11,7 +11,7 @@ class ScriptCheckable < ::HTML::Proofer::Checkable
   end
 
   def blank?
-    @content.strip.empty?
+    @text.strip.empty?
   end
 
 end

--- a/spec/html/proofer/checkable_spec.rb
+++ b/spec/html/proofer/checkable_spec.rb
@@ -37,4 +37,11 @@ describe HTML::Proofer::Checkable do
       expect(checkable.url).to eq 'image.png'
     end
   end
+  describe '#ignore' do
+    it 'works for twitter cards' do
+      nokogiri = Nokogiri::HTML '<meta name="twitter:url" data-proofer-ignore content="http://example.com/soon-to-be-published-url">'
+      checkable = HTML::Proofer::Checkable.new nokogiri.css('meta').first, nil
+      expect(checkable.ignore?).to eq true
+    end
+  end
 end

--- a/spec/html/proofer/checkable_spec.rb
+++ b/spec/html/proofer/checkable_spec.rb
@@ -2,10 +2,20 @@ require 'spec_helper'
 
 describe HTML::Proofer::Checkable do
   describe '#initialize' do
-    it 'accepts xmlns attribute' do
+    it 'accepts the xmlns attribute' do
       nokogiri = Nokogiri::HTML '<a xmlns:cc="http://creativecommons.org/ns#">Creative Commons</a>'
       checkable = HTML::Proofer::Checkable.new nokogiri.css('a').first, nil
       expect(checkable.instance_variable_get(:@xmlns_cc)).to eq 'http://creativecommons.org/ns#'
+    end
+    it 'assignes the text node' do
+      nokogiri = Nokogiri::HTML '<p>One'
+      checkable = HTML::Proofer::Checkable.new nokogiri.css('p').first, nil
+      expect(checkable.instance_variable_get(:@text)).to eq 'One'
+    end
+    it 'accepts the content attribute' do
+      nokogiri = Nokogiri::HTML '<meta name="twitter:card" content="summary">'
+      checkable = HTML::Proofer::Checkable.new nokogiri.css('meta').first, nil
+      expect(checkable.instance_variable_get(:@content)).to eq 'summary'
     end
   end
   describe '#ignores_pattern_check' do


### PR DESCRIPTION
This fixes the bug noticed in https://github.com/gjtorikian/html-proofer/issues/213#issuecomment-99411107