### PR TITLE
Checkable#file_path: allow for dropping html extension.

### DIFF
--- a/lib/html/proofer/checkable.rb
+++ b/lib/html/proofer/checkable.rb
@@ -117,6 +117,8 @@ module HTML
         # implicit index support
         if File.directory?(file) && !unslashed_directory?(file)
           file = File.join file, @check.options[:directory_index_file]
+        elsif File.file?("#{file}.html")
+          file = "#{file}.html"
         end
 
         file

--- a/lib/html/proofer/checkable.rb
+++ b/lib/html/proofer/checkable.rb
@@ -112,7 +112,12 @@ module HTML
           base = @check.path
         end
 
-        file = File.join base, path
+        file = if File.directory? base
+          File.join path, base
+        else
+          # Behave like HTML internal linking.
+          File.expand_path path, File.dirname(base)
+        end
 
         # implicit index support
         if File.directory?(file) && !unslashed_directory?(file)

--- a/spec/html/proofer/fixtures/links/no_html_extension.html
+++ b/spec/html/proofer/fixtures/links/no_html_extension.html
@@ -1,0 +1,1 @@
+<a href="githubHash">i forgot the html path on purpose!</a>

--- a/spec/html/proofer/links_spec.rb
+++ b/spec/html/proofer/links_spec.rb
@@ -361,4 +361,10 @@ describe 'Links test' do
     proofer = run_proofer(fixture)
     expect(proofer.failed_tests).to eq []
   end
+
+  it 'does not complain when the link drops the .html extension' do
+    fixture = "#{FIXTURES_DIR}/links/no_html_extension.html"
+    proofer = run_proofer(fixture)
+    expect(proofer.failed_tests).to eq []
+  end
 end


### PR DESCRIPTION
Using a new feature in Jekyll 3 which allows you to drop the `.html` in the links. Yields this error:

```text
- ./_site/go/index.html
  *  internally linking to /go/jekyll-build-server, which does not exist (line 50)
  *  internally linking to /go/merge-pr, which does not exist (line 58)
HTML-Proofer found 2 failures!
```

This is a fix for this new feature coming in Jekyll 3.

Maybe related to #195? /cc @gjtorikian @penibelst 