### PR TITLE
Add line numbers to failing HTML checks

### DIFF
--- a/lib/html/proofer/checks/html.rb
+++ b/lib/html/proofer/checks/html.rb
@@ -34,7 +34,7 @@ class HtmlCheck < ::HTML::Proofer::CheckRunner
       # so we need to skip errors caused by the new tags in html5
       next if HTML5_TAGS.include? e.to_s[/Tag ([\w-]+) invalid/o, 1]
 
-      add_issue(e.to_s)
+      add_issue(e.to_s, e.line)
     end
   end
 end

--- a/spec/html/proofer/html_spec.rb
+++ b/spec/html/proofer/html_spec.rb
@@ -22,19 +22,19 @@ describe 'Html test' do
   it 'fails for an invalid tag' do
     html = "#{FIXTURES_DIR}/html/invalid_tag.html"
     proofer = run_proofer(html, { :check_html => true })
-    expect(proofer.failed_tests.first).to match(/Tag myfancytag invalid/)
+    expect(proofer.failed_tests.first).to match(/Tag myfancytag invalid \(line 2\)/)
   end
 
   it 'fails for an unmatched end tag' do
     html = "#{FIXTURES_DIR}/html/unmatched_end_tag.html"
     proofer = run_proofer(html, { :check_html => true })
-    expect(proofer.failed_tests.first).to match(/Unexpected end tag : div/)
+    expect(proofer.failed_tests.first).to match(/Unexpected end tag : div \(line 3\)/)
   end
 
   it 'fails for an unescaped ampersand in attribute' do
     html = "#{FIXTURES_DIR}/html/unescaped_ampersand_in_attribute.html"
     proofer = run_proofer(html, { :check_html => true })
-    expect(proofer.failed_tests.first).to match(/htmlParseEntityRef: expecting ';'/)
+    expect(proofer.failed_tests.first).to match(/htmlParseEntityRef: expecting ';' \(line 2\)/)
   end
 
   it 'fails for mismatch between opening and ending tag' do
@@ -46,12 +46,12 @@ describe 'Html test' do
   it 'fails for div inside head' do
     html = "#{FIXTURES_DIR}/html/div_inside_head.html"
     proofer = run_proofer(html, { :check_html => true })
-    expect(proofer.failed_tests.first).to match(/Unexpected end tag : head/)
+    expect(proofer.failed_tests.first).to match(/Unexpected end tag : head \(line 5\)/)
   end
 
   it 'fails for missing closing quotation mark in href' do
     html = "#{FIXTURES_DIR}/html/missing_closing_quotes.html"
     proofer = run_proofer(html, { :check_html => true })
-    expect(proofer.failed_tests.to_s).to match(/Couldn't find end of Start Tag a/)
+    expect(proofer.failed_tests.to_s).to match(/Couldn't find end of Start Tag a \(line 6\)/)
   end
 end


### PR DESCRIPTION
Closes https://github.com/gjtorikian/html-proofer/issues/232.

