### PR TITLE
Loosen up query check

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ The `HTML::Proofer` constructor takes an optional hash of additional options:
 | `only_4xx` | Only reports errors for links that fall within the 4xx status code range. | `false` |
 | `url_ignore` | An array of Strings or RegExps containing URLs that are safe to ignore. It affects all HTML attributes. Note that non-HTTP(S) URIs are always ignored. | `[]` |
 | `verbose` | If `true`, outputs extra information as the checking happens. Useful for debugging. | `false` |
+| `verbosity` | Sets the logging level, as determined by [Yell](https://github.com/rudionrails/yell). | `:info`
 
 ### Configuring Typhoeus and Hydra
 
@@ -194,6 +195,15 @@ HTML::Proofer.new("out/", {:ext => ".htm", :parallel => { :in_processes => 3} })
 ```
 
 In this example, `:in_processes => 3` is passed into Parallel as a configuration option.
+
+## Logging
+
+HTML-Proofer can be as noisy or as quiet as you'd like. There are two ways to log information:
+
+* If you set the `:verbose` option to `true`, HTML-Proofer will provide some debug information.
+* If you set the `:verbosity` option, you can better define the level of logging. See the configuration table above for more information.
+
+`:verbosity` is newer and offers better configuration. `:verbose` will be deprecated in a future 3.x.x release.
 
 ## Custom tests
 

--- a/README.md
+++ b/README.md
@@ -164,12 +164,12 @@ The `HTML::Proofer` constructor takes an optional hash of additional options:
 | `error_sort` | Defines the sort order for error output. Can be `:path`, `:desc`, or `:status`. | `:path`
 | `ext` | The extension of your HTML files including the dot. | `.html`
 | `file_ignore` | An array of Strings or RegExps containing file paths that are safe to ignore. | `[]` |
-| `href_ignore` | An array of Strings or RegExps containing `href`s that are safe to ignore. Note that non-HTTP(S) URIs are always ignored. | `[]` |
-| `href_swap` | A hash containing key-value pairs of `RegExp => String`. It transforms links that match `RegExp` into `String` via `gsub`. | `{}` |
+| `href_ignore` | An array of Strings or RegExps containing `href`s that are safe to ignore. Note that non-HTTP(S) URIs are always ignored. **Will be renamed in a future release.** | `[]` |
+| `href_swap` | A hash containing key-value pairs of `RegExp => String`. It transforms links that match `RegExp` into `String` via `gsub`. **Will be renamed in a future release.** | `{}` |
 | `ignore_script_embeds` | When `check_html` is enabled, `script` tags containing markup [are reported as errors](http://git.io/vOovv). Enabling this option ignores those errors. | `false`
 | `only_4xx` | Only reports errors for links that fall within the 4xx status code range. | `false` |
 | `url_ignore` | An array of Strings or RegExps containing URLs that are safe to ignore. It affects all HTML attributes. Note that non-HTTP(S) URIs are always ignored. | `[]` |
-| `verbose` | If `true`, outputs extra information as the checking happens. Useful for debugging. | `false` |
+| `verbose` | If `true`, outputs extra information as the checking happens. Useful for debugging. **Will be deprecated in a future release.**| `false` |
 | `verbosity` | Sets the logging level, as determined by [Yell](https://github.com/rudionrails/yell). | `:info`
 
 ### Configuring Typhoeus and Hydra

--- a/README.md
+++ b/README.md
@@ -22,15 +22,9 @@ Or install it yourself as:
 
 **NOTE:** When installation speed matters, set `NOKOGIRI_USE_SYSTEM_LIBRARIES` to `true` in your environment. This is useful for increasing the speed of your Continuous Integration builds.
 
-### Real-life examples
-
-Project | Repository
-:--- | :---
-[Raspberry Pi documentation](http://www.raspberrypi.org/documentation/) | [raspberrypi/documentation]( https://github.com/raspberrypi/documentation)
-[Open Whisper Systems website](https://whispersystems.org/) | [WhisperSystems/whispersystems.org](https://github.com/WhisperSystems/whispersystems.org)
-[Jekyll website](http://jekyllrb.com/) | [jekyll/jekyll](https://github.com/jekyll/jekyll)
-
 ## What's Tested?
+
+You can enable or disable most of the following checks.
 
 ### Images
 
@@ -44,24 +38,24 @@ Project | Repository
 
 `a`, `link` elements:
 
-* Whether your internal links are not broken; this includes hash references (`#linkToMe`)
+* Whether your internal links are working
+* Whether your internal hash references (`#linkToMe`) are working
 * Whether external links are working
 
 ### Scripts
 
 `script` elements:
 
-* Whether your internal script references are not broken
+* Whether your internal script references are working
 * Whether external scripts are loading
 
 ### Favicon
 
-Checks if your favicons are valid. This is an optional feature, set the `check_favicon` option to turn it on.
+* Whether your favicons are valid.
 
 ### HTML
 
-Nokogiri looks at the markup and [provides errors](http://www.nokogiri.org/tutorials/ensuring_well_formed_markup.html) when parsing your document.
-This is an optional feature, set the `check_html` option to enable validation errors from Nokogiri.
+* Whether your HTML markup is valid. This is done via [Nokogiri, to ensure well-formed markup](http://www.nokogiri.org/tutorials/ensuring_well_formed_markup.html).
 
 ## Usage
 
@@ -125,10 +119,32 @@ task :test do
 end
 ```
 
-Don't have or want a `Rakefile`? You _could_ also do something like the following:
+Don't have or want a `Rakefile`? You can also do something like the following:
 
 ```bash
 htmlproof ./_site
+```
+
+### Array of links
+
+Instead of a directory as the first argument, you can also pass in an array of links:
+
+``` ruby
+HTML::Proofer.new(["http://github.com", "http://jekyllrb.com"])
+```
+
+This configures Proofer to just test those links to ensure they are valid. Note that for the command-line, you'll need to pass a special `--as-links` argument:
+
+``` bash
+htmlproof www.google.com,www.github.com --as-links
+```
+
+## Ignoring content
+
+Add the `data-proofer-ignore` attribute to any tag to ignore it from every check.
+
+``` html
+<a href="http://notareallink" data-proofer-ignore>Not checked.</a>
 ```
 
 ## Configuration
@@ -163,7 +179,7 @@ The `HTML::Proofer` constructor takes an optional hash of additional options:
 HTML::Proofer.new("out/", {:ext => ".htm", :typhoeus => { :verbose => true, :ssl_verifyhost => 2 } })
 ```
 
-This sets `HTML::Proofer`'s extensions to use _.htm_, and gives Typhoeus a configuration for it to be verbose, and use specific SSL settings. Check [the Typhoeus documentation](https://github.com/typhoeus/typhoeus#other-curl-options) for more information on what options it can receive.
+This sets `HTML::Proofer`'s extensions to use _.htm_, gives Typhoeus a configuration for it to be verbose, and use specific SSL settings. Check [the Typhoeus documentation](https://github.com/typhoeus/typhoeus#other-curl-options) for more information on what options it can receive.
 
 You can similarly pass in a `:hydra` option with a hash configuration for Hydra.
 
@@ -171,40 +187,17 @@ The default value is `typhoeus => { :followlocation => true }`.
 
 ### Configuring Parallel
 
-[Parallel](https://github.com/grosser/parallel) is being used to speed internal file checks. You can pass in any of its options with the options "namespace" `:parallel`. For example:
+[Parallel](https://github.com/grosser/parallel) is used to speed internal file checks. You can pass in any of its options with the options namespace `:parallel`. For example:
 
 ``` ruby
 HTML::Proofer.new("out/", {:ext => ".htm", :parallel => { :in_processes => 3} })
 ```
 
-`:in_processes => 3` will be passed into Parallel as a configuration option.
-
-### Array of links
-
-Instead of a directory as the first argument, you can also pass in an array of links:
-
-``` ruby
-HTML::Proofer.new(["http://github.com", "http://jekyllrb.com"])
-```
-
-This configures Proofer to just test those links to ensure they are valid. Note that for the command-line, you'll need to pass a special `--as-links` argument:
-
-``` bash
-bin/htmlproof www.google.com,www.github.com --as-links
-```
-
-## Ignoring content
-
-Add the `data-proofer-ignore` attribute to any tag to ignore it from the checks.
-
-
-``` html
-<a href="http://notareallink" data-proofer-ignore>Not checked.</a>
-```
+In this example, `:in_processes => 3` is passed into Parallel as a configuration option.
 
 ## Custom tests
 
-Want to write your own test? Sure! Just create two classes--one that inherits from `HTML::Proofer::CheckRunner`, and another that inherits from `HTML::Proofer::Checkable`.
+Want to write your own test? Sure! Just create two classes--one that inherits from `HTML::Proofer::Checkable`, and another that inherits from `HTML::Proofer::CheckRunner`.
 
 The `CheckRunner` subclass must define one method called `run`. This is called on your content, and is responsible for performing the validation on whatever elements you like. When you catch a broken issue, call `add_issue(message)` to explain the error.
 
@@ -214,7 +207,6 @@ Here's an example custom test that protects against `mailto` links that point to
 
 ``` ruby
 class OctocatLinkCheck < ::HTML::Proofer::Checkable
-
   def mailto?
     return false if @data_ignore_proofer || @href.nil? || @href.empty?
     return @href.match /^mailto\:/
@@ -227,7 +219,6 @@ class OctocatLinkCheck < ::HTML::Proofer::Checkable
 end
 
 class MailToOctocat < ::HTML::Proofer::CheckRunner
-
   def run
     @html.css('a').each do |l|
       link = OctocatLinkCheck.new l, self
@@ -244,7 +235,7 @@ end
 
 ### Certificates
 
-To ignore certificates turn off the Typhoeus SSL verification:
+To ignore certificates, turn off Typhoeus' SSL verification:
 
 ``` ruby
 HTML::Proofer.new("out/", {
@@ -264,3 +255,11 @@ HTML::Proofer.new("out/", {
     :headers => { "User-Agent" => "Mozilla/5.0 (compatible; My New User-Agent)" }
 }}).run
 ```
+
+## Real-life examples
+
+Project | Repository
+:--- | :---
+[Raspberry Pi documentation](http://www.raspberrypi.org/documentation/) | [raspberrypi/documentation]( https://github.com/raspberrypi/documentation)
+[Open Whisper Systems website](https://whispersystems.org/) | [WhisperSystems/whispersystems.org](https://github.com/WhisperSystems/whispersystems.org)
+[Jekyll website](http://jekyllrb.com/) | [jekyll/jekyll](https://github.com/jekyll/jekyll)

--- a/README.md
+++ b/README.md
@@ -230,11 +230,12 @@ end
 
 class MailToOctocat < ::HTML::Proofer::CheckRunner
   def run
-    @html.css('a').each do |l|
-      link = OctocatLinkCheck.new l, self
+    @html.css('a').each do |node|
+      link = OctocatLinkCheck.new(node, self)
+      line = node.line
 
       if link.mailto? && link.octocat?
-        return add_issue("Don't email the Octocat directly!")
+        return add_issue("Don't email the Octocat directly!", line)
       end
     end
   end

--- a/bin/htmlproof
+++ b/bin/htmlproof
@@ -40,6 +40,7 @@ Mercenary.program(:htmlproof) do |p|
   p.option 'only_4xx', '--only-4xx', 'Only reports errors for links that fall within the 4x status code range.'
   p.option 'url_ignore', '--url-ignore link1,[link2,...]', Array, 'Comma-separated list of Strings or RegExps containing URLs that are safe to ignore.'
   p.option 'verbose', '--verbose', 'Enables more verbose logging.'
+  p.option 'verbosity', '--verbosity', String, 'Sets the logging level, as determined by Yell'
 
   p.action do |args, opts|
     args = ['.'] if args.empty?
@@ -47,7 +48,7 @@ Mercenary.program(:htmlproof) do |p|
 
     options = {}
 
-    # prepare every to go to proofer
+    # prepare everything to go to proofer
     p.options.select { |o| !opts[o.config_key].nil? }.each do |option|
       if option.return_type.to_s == 'Array' # TODO: is_a? doesn't work here?
         opts[option.config_key] = opts[option.config_key].map { |i| to_regex?(i) }
@@ -65,6 +66,7 @@ Mercenary.program(:htmlproof) do |p|
     end
 
     options[:error_sort] = opts['error-sort'].to_sym unless opts['error-sort'].nil?
+    options[:verbosity] = opts['verbosity'].to_sym unless opts['verbosity'].nil?
 
     path = path.delete(' ').split(',') if opts['as_links']
 

--- a/bin/htmlproof
+++ b/bin/htmlproof
@@ -8,7 +8,7 @@ require 'mercenary'
 require 'rubygems'
 
 def to_regex?(item)
-  if item.start_with? '/' and item.end_with? '/'
+  if item.start_with?('/') && item.end_with?('/')
     Regexp.new item[1...-1]
   else
     item

--- a/lib/html/proofer.rb
+++ b/lib/html/proofer.rb
@@ -20,14 +20,14 @@ rescue LoadError; end
 module HTML
 
   class Proofer
-    include Utils
+    include HTML::Proofer::Utils
 
     attr_reader :options, :typhoeus_opts, :hydra_opts, :parallel_opts, :validation_opts, :external_urls
 
     TYPHOEUS_DEFAULTS = {
       :followlocation => true,
       :headers => {
-        "User-Agent" => "Mozilla/5.0 (compatible; HTML Proofer/#{VERSION}; +https://github.com/gjtorikian/html-proofer)"
+        'User-Agent' => "Mozilla/5.0 (compatible; HTML Proofer/#{VERSION}; +https://github.com/gjtorikian/html-proofer)"
       }
     }
 

--- a/lib/html/proofer.rb
+++ b/lib/html/proofer.rb
@@ -34,6 +34,13 @@ module HTML
     def initialize(src, opts = {})
       @src = src
 
+      if opts[:verbose]
+        warn '`@options[:verbose]` will be removed in a future 3.x.x release: http://git.io/vGHHh'
+      end
+      if opts[:href_ignore]
+        warn '`@options[:href_ignore]` will be renamed in a future 3.x.x release: http://git.io/vGHHy'
+      end
+
       @proofer_opts = {
         :ext => '.html',
         :check_favicon => false,
@@ -72,7 +79,7 @@ module HTML
     end
 
     def logger
-      @logger ||= HTML::Proofer::Log.new(@options[:verbose])
+      @logger ||= HTML::Proofer::Log.new(@options[:verbose], @options[:verbosity])
     end
 
     def run

--- a/lib/html/proofer/check_runner.rb
+++ b/lib/html/proofer/check_runner.rb
@@ -6,7 +6,8 @@ module HTML
     class CheckRunner
 
       attr_reader :issues, :src, :path, :options, :typhoeus_opts, :hydra_opts, :parallel_opts, \
-                  :validation_opts, :external_urls, :href_ignores, :url_ignores, :alt_ignores, :empty_alt_ignore
+                  :validation_opts, :external_urls, :href_ignores, :url_ignores, :alt_ignores, \
+                  :empty_alt_ignore
 
       def initialize(src, path, html, options, typhoeus_opts, hydra_opts, parallel_opts, validation_opts)
         @src    = src
@@ -34,7 +35,7 @@ module HTML
         @issues << Issue.new(@path, desc, line_number, status)
       end
 
-      def add_to_external_urls(url)
+      def add_to_external_urls(url, line)
         return if @external_urls[url]
         uri = Addressable::URI.parse(url)
 

--- a/lib/html/proofer/check_runner.rb
+++ b/lib/html/proofer/check_runner.rb
@@ -23,6 +23,7 @@ module HTML
         @alt_ignores = @options[:alt_ignore]
         @empty_alt_ignore = @options[:empty_alt_ignore]
         @external_urls = {}
+        @external_domain_paths_with_queries = {}
       end
 
       def run
@@ -33,12 +34,43 @@ module HTML
         @issues << Issue.new(@path, desc, line_number, status)
       end
 
-      def add_to_external_urls(href)
-        if @external_urls[href]
-          @external_urls[href] << @path
+      def add_to_external_urls(url)
+        return if @external_urls[url]
+        uri = Addressable::URI.parse(url)
+
+        if uri.query.nil?
+          add_path_for_url(url)
         else
-          @external_urls[href] = [@path]
+          new_url_query_values?(uri, url)
         end
+      end
+
+      def add_path_for_url(url)
+        if @external_urls[url]
+          @external_urls[url] << @path
+        else
+          @external_urls[url] = [@path]
+        end
+      end
+
+      def new_url_query_values?(uri, url)
+        queries = uri.query_values.keys.join('-')
+        domain_path = extract_domain_path(uri)
+        if @external_domain_paths_with_queries[domain_path].nil?
+          add_path_for_url(url)
+          # remember queries we've seen, ignore future ones
+          @external_domain_paths_with_queries[domain_path] = [queries]
+        else
+          # add queries we haven't seen
+          unless @external_domain_paths_with_queries[domain_path].include?(queries)
+            add_path_for_url(url)
+            @external_domain_paths_with_queries[domain_path] << queries
+          end
+        end
+      end
+
+      def extract_domain_path(uri)
+        uri.host + uri.path
       end
 
       def self.checks
@@ -52,7 +84,7 @@ module HTML
         classes
       end
 
-    private
+      private
 
       def remove_ignored(html)
         html.css('code, pre').each(&:unlink)

--- a/lib/html/proofer/checkable.rb
+++ b/lib/html/proofer/checkable.rb
@@ -5,7 +5,8 @@ module HTML
   class Proofer
     # Represents the superclass from which all checks derive.
     class Checkable
-      include HTML::Utils
+      include HTML::Proofer::Utils
+
       attr_reader :line
 
       def initialize(obj, check)
@@ -75,12 +76,12 @@ module HTML
         return true if ignores_pattern_check(@check.url_ignores)
 
         # ignore user defined hrefs
-        if 'LinkCheckable' === @type
+        if 'LinkCheckable' == @type
           return true if ignores_pattern_check(@check.href_ignores)
         end
 
         # ignore user defined alts
-        if 'ImageCheckable' === @type
+        if 'ImageCheckable' == @type
           return true if ignores_pattern_check(@check.alt_ignores)
         end
       end
@@ -102,7 +103,7 @@ module HTML
       def file_path
         return if path.nil?
 
-        if path =~ /^\// # path relative to root
+        if path =~ %r{^/} # path relative to root
           base = File.directory?(@check.src) ? @check.src : File.dirname(@check.src)
         elsif File.exist?(File.expand_path path, @check.src) # relative links, path is a file
           base = File.dirname @check.path
@@ -158,7 +159,6 @@ module HTML
       def real_attr(attr)
         attr.to_s unless attr.nil? || attr.empty?
       end
-
     end
   end
 end

--- a/lib/html/proofer/checks/favicon.rb
+++ b/lib/html/proofer/checks/favicon.rb
@@ -1,21 +1,21 @@
 # encoding: utf-8
 
 class FaviconCheckable < ::HTML::Proofer::Checkable
-  def rel
-    @rel
-  end
+  attr_reader :rel
 end
 
 class FaviconCheck < ::HTML::Proofer::CheckRunner
-
   def run
-    @html.xpath('//link[not(ancestor::pre or ancestor::code)]').each do |favicon|
-      favicon = FaviconCheckable.new favicon, self
+    found = false
+    @html.xpath('//link[not(ancestor::pre or ancestor::code)]').each do |node|
+      favicon = FaviconCheckable.new(node, self)
       next if favicon.ignore?
-      return if favicon.rel.split(' ').last.eql? 'icon'
+      found = true if favicon.rel.split(' ').last.eql? 'icon'
+      break if found
     end
+
+    return if found
 
     add_issue 'no favicon specified'
   end
-
 end

--- a/lib/html/proofer/checks/html.rb
+++ b/lib/html/proofer/checks/html.rb
@@ -27,16 +27,18 @@ class HtmlCheck < ::HTML::Proofer::CheckRunner
                   rect set stop switch symbol text textPath tref tspan use
                   view vkern)
 
+  SCRIPT_EMBEDS_MSG = /Element script embeds close tag/
+
   def run
-    @html.errors.each do |e|
-      message = e.message
-      line    = e.line
+    @html.errors.each do |error|
+      message = error.message
+      line    = error.line
       # Nokogiri (or rather libxml2 underhood) only recognizes html4 tags,
       # so we need to skip errors caused by the new tags in html5
       next if HTML5_TAGS.include? message[/Tag ([\w-]+) invalid/o, 1]
 
       # tags embedded in scripts are used in templating languages: http://git.io/vOovv
-      next if @validation_opts[:ignore_script_embeds] && message =~ /Element script embeds close tag/
+      next if @validation_opts[:ignore_script_embeds] && message =~ SCRIPT_EMBEDS_MSG
 
       add_issue(message, line)
     end

--- a/lib/html/proofer/checks/images.rb
+++ b/lib/html/proofer/checks/images.rb
@@ -1,12 +1,9 @@
 # encoding: utf-8
 
 class ImageCheckable < ::HTML::Proofer::Checkable
-
   SCREEN_SHOT_REGEX = /Screen(?: |%20)Shot(?: |%20)\d+-\d+-\d+(?: |%20)at(?: |%20)\d+.\d+.\d+/
 
-  def alt
-    @alt
-  end
+  attr_reader :alt
 
   def empty_alt_tag?
     alt.strip.empty?
@@ -23,32 +20,32 @@ class ImageCheckable < ::HTML::Proofer::Checkable
   def missing_src?
     !src
   end
-
 end
 
 class ImageCheck < ::HTML::Proofer::CheckRunner
   def run
-    @html.css('img').each do |i|
-      img = ImageCheckable.new i, self
+    @html.css('img').each do |node|
+      img = ImageCheckable.new(node, self)
+      line = node.line
 
       next if img.ignore?
 
       # screenshot filenames should return because of terrible names
-      next add_issue("image has a terrible filename (#{img.src})", i.line) if img.terrible_filename?
+      next add_issue("image has a terrible filename (#{img.src})", line) if img.terrible_filename?
 
       # does the image exist?
       if img.missing_src?
-        add_issue('image has no src or srcset attribute', i.line)
+        add_issue('image has no src or srcset attribute', line)
       else
         if img.remote?
-          add_to_external_urls img.src
+          add_to_external_urls(img.src, line)
         else
-          add_issue("internal image #{img.src} does not exist", i.line) unless img.exists?
+          add_issue("internal image #{img.src} does not exist", line) unless img.exists?
         end
       end
 
       if img.alt.nil? || (img.empty_alt_tag? && !img.ignore_empty_alt?)
-        add_issue("image #{img.src} does not have an alt attribute", i.line)
+        add_issue("image #{img.src} does not have an alt attribute", line)
       end
     end
 

--- a/lib/html/proofer/checks/scripts.rb
+++ b/lib/html/proofer/checks/scripts.rb
@@ -18,19 +18,20 @@ end
 
 class ScriptCheck < ::HTML::Proofer::CheckRunner
   def run
-    @html.css('script').each do |s|
-      script = ScriptCheckable.new s, self
+    @html.css('script').each do |node|
+      script = ScriptCheckable.new(node, self)
+      line = node.line
 
       next if script.ignore?
       next unless script.blank?
 
       # does the script exist?
       if script.missing_src?
-        add_issue('script is empty and has no src attribute', s.line)
+        add_issue('script is empty and has no src attribute', line)
       elsif script.remote?
-        add_to_external_urls script.src
+        add_to_external_urls(script.src, line)
       else
-        add_issue("internal script #{script.src} does not exist", s.line) unless script.exists?
+        add_issue("internal script #{script.src} does not exist", line) unless script.exists?
       end
     end
 

--- a/lib/html/proofer/log.rb
+++ b/lib/html/proofer/log.rb
@@ -6,8 +6,12 @@ module HTML
     class Log
       include Yell::Loggable
 
-      def initialize(verbose)
-        log_level = verbose ? :debug : :info
+      def initialize(verbose, verbosity = nil)
+        log_level = if verbosity.nil?
+                      verbose ? :debug : :info
+                    else
+                      verbosity
+                    end
 
         @logger = Yell.new(:format => false, \
                            :name => 'HTML::Proofer', \

--- a/lib/html/proofer/url_validator.rb
+++ b/lib/html/proofer/url_validator.rb
@@ -129,7 +129,6 @@ module HTML
       rescue URI::InvalidURIError
         nil
       end
-
     end
   end
 end

--- a/lib/html/proofer/url_validator.rb
+++ b/lib/html/proofer/url_validator.rb
@@ -5,7 +5,7 @@ require_relative './utils'
 module HTML
   class Proofer
     class UrlValidator
-      include Utils
+      include HTML::Proofer::Utils
 
       attr_accessor :logger, :external_urls, :hydra
 
@@ -74,6 +74,7 @@ module HTML
         href = response.request.base_url.to_s
         method = response.request.options[:method]
         response_code = response.code
+
         debug_msg = "Received a #{response_code} for #{href}"
         debug_msg << " in #{filenames.join(' ')}" unless filenames.nil?
         logger.log :debug, :yellow, debug_msg
@@ -87,7 +88,7 @@ module HTML
         else
           return if @options[:only_4xx] && !response_code.between?(400, 499)
           # Received a non-successful http response.
-          add_failed_tests filenames, "External link #{href} failed: #{response_code} #{response.return_message}", response_code
+          add_external_issue(filenames, "External link #{href} failed: #{response_code} #{response.return_message}", response_code)
         end
       end
 
@@ -108,15 +109,15 @@ module HTML
 
         return unless body_doc.xpath(xpath).empty?
 
-        add_failed_tests filenames, "External link #{href} failed: #{effective_url} exists, but the hash '#{hash}' does not", response.code
+        add_external_issue filenames, "External link #{href} failed: #{effective_url} exists, but the hash '#{hash}' does not", response.code
       end
 
       def handle_timeout(href, filenames, response_code)
         return if @options[:only_4xx]
-        add_failed_tests filenames, "External link #{href} failed: got a time out", response_code
+        add_external_issue filenames, "External link #{href} failed: got a time out", response_code
       end
 
-      def add_failed_tests(filenames, desc, status = nil)
+      def add_external_issue(filenames, desc, status = nil)
         if filenames.nil?
           @failed_tests << CheckRunner::Issue.new('', desc, nil, status)
         else

--- a/lib/html/proofer/utils.rb
+++ b/lib/html/proofer/utils.rb
@@ -1,24 +1,26 @@
 require 'nokogiri'
 
 module HTML
-  module Utils
-    def create_nokogiri(path)
-      if File.exist? path
-        content = File.open(path).read
-      else
-        content = path
-      end
+  class Proofer
+    module Utils
+      def create_nokogiri(path)
+        if File.exist? path
+          content = File.open(path).read
+        else
+          content = path
+        end
 
-      Nokogiri::HTML(content)
-    end
-    module_function :create_nokogiri
-
-    def swap(href, replacement)
-      replacement.each do |link, replace|
-        href = href.gsub(link, replace)
+        Nokogiri::HTML(content)
       end
-      href
+      module_function :create_nokogiri
+
+      def swap(href, replacement)
+        replacement.each do |link, replace|
+          href = href.gsub(link, replace)
+        end
+        href
+      end
+      module_function :swap
     end
-    module_function :swap
   end
 end

--- a/spec/html/proofer/fixtures/links/check_just_once.html
+++ b/spec/html/proofer/fixtures/links/check_just_once.html
@@ -1,0 +1,8 @@
+<a href="https://github.com/contact?form%5Bsubject%5D=New+Assigned+Events">First</a>
+
+<a href="https://github.com/contact?form%5Bsubject%5D=Organization+and+Team+Membership+APIs">Ignored</a>
+
+<a href="https://github.com/contact#false?form%5Bsubject%5D=Organization+and+Team+Membership+APIs">Second, because of hash</a>
+
+
+<a href="https://github.com/contact?form%5Bsubject%5D=Blah+and+blah+blah+APIs">Ignored</a>

--- a/spec/html/proofer/fixtures/vcr_cassettes/links/check_just_once_html.yml
+++ b/spec/html/proofer/fixtures/vcr_cassettes/links/check_just_once_html.yml
@@ -1,0 +1,87 @@
+---
+http_interactions:
+- request:
+    method: head
+    uri: https://github.com/contact#false?form%5Bsubject%5D=Organization+and+Team+Membership+APIs
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/2.4.2; +https://github.com/gjtorikian/html-proofer)
+  response:
+    status:
+      code: 0
+      message: 
+    headers: {}
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+    adapter_metadata:
+      effective_url: https://github.com/contact
+  recorded_at: Fri, 04 Sep 2015 21:28:18 GMT
+- request:
+    method: head
+    uri: https://github.com/contact?form%5Bsubject%5D=New+Assigned+Events
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/2.4.2; +https://github.com/gjtorikian/html-proofer)
+  response:
+    status:
+      code: 0
+      message: 
+    headers: {}
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+    adapter_metadata:
+      effective_url: https://github.com/contact?form%5Bsubject%5D=New+Assigned+Events
+  recorded_at: Fri, 04 Sep 2015 21:28:18 GMT
+- request:
+    method: get
+    uri: https://github.com/contact#false?form%5Bsubject%5D=Organization+and+Team+Membership+APIs
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/2.4.2; +https://github.com/gjtorikian/html-proofer)
+  response:
+    status:
+      code: 0
+      message: 
+    headers: {}
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+    adapter_metadata:
+      effective_url: https://github.com/contact
+  recorded_at: Fri, 04 Sep 2015 21:28:18 GMT
+- request:
+    method: get
+    uri: https://github.com/contact?form%5Bsubject%5D=New+Assigned+Events
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/2.4.2; +https://github.com/gjtorikian/html-proofer)
+  response:
+    status:
+      code: 0
+      message: 
+    headers: {}
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+    adapter_metadata:
+      effective_url: https://github.com/contact?form%5Bsubject%5D=New+Assigned+Events
+  recorded_at: Fri, 04 Sep 2015 21:28:18 GMT
+recorded_with: VCR 2.9.3

--- a/spec/html/proofer/fixtures/vcr_cassettes/sorting/status_verbosity_info_typhoeus_followlocation_false_error_sort_status_.yml
+++ b/spec/html/proofer/fixtures/vcr_cassettes/sorting/status_verbosity_info_typhoeus_followlocation_false_error_sort_status_.yml
@@ -1,0 +1,244 @@
+---
+http_interactions:
+- request:
+    method: head
+    uri: http://upload.wikimedia.org/wikipedia/en/thumb/fooooof.png
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/2.4.2; +https://github.com/gjtorikian/html-proofer)
+  response:
+    status:
+      code: 301
+      message: TLS Redirect
+    headers:
+      Server:
+      - Varnish
+      Location:
+      - https://upload.wikimedia.org/wikipedia/en/thumb/fooooof.png
+      Content-Length:
+      - '0'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 08 Sep 2015 01:24:41 GMT
+      X-Varnish:
+      - '834465226'
+      Age:
+      - '0'
+      Via:
+      - 1.1 varnish
+      Connection:
+      - close
+      X-Cache:
+      - cp1074 frontend miss (0)
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Age, Date, Content-Length, Content-Range, X-Content-Duration, X-Cache, X-Varnish
+      Timing-Allow-Origin:
+      - "*"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: http://upload.wikimedia.org/wikipedia/en/thumb/fooooof.png
+  recorded_at: Tue, 08 Sep 2015 01:24:42 GMT
+- request:
+    method: head
+    uri: http://upload.wikimedia.org/wikipedia/en/thumb/not_here.png
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/2.4.2; +https://github.com/gjtorikian/html-proofer)
+  response:
+    status:
+      code: 301
+      message: TLS Redirect
+    headers:
+      Server:
+      - Varnish
+      Location:
+      - https://upload.wikimedia.org/wikipedia/en/thumb/not_here.png
+      Content-Length:
+      - '0'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 08 Sep 2015 01:24:42 GMT
+      X-Varnish:
+      - '2973907557'
+      Age:
+      - '0'
+      Via:
+      - 1.1 varnish
+      Connection:
+      - close
+      X-Cache:
+      - cp1071 frontend miss (0)
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Age, Date, Content-Length, Content-Range, X-Content-Duration, X-Cache, X-Varnish
+      Timing-Allow-Origin:
+      - "*"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: http://upload.wikimedia.org/wikipedia/en/thumb/not_here.png
+  recorded_at: Tue, 08 Sep 2015 01:24:42 GMT
+- request:
+    method: get
+    uri: http://upload.wikimedia.org/wikipedia/en/thumb/fooooof.png
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/2.4.2; +https://github.com/gjtorikian/html-proofer)
+  response:
+    status:
+      code: 301
+      message: TLS Redirect
+    headers:
+      Server:
+      - Varnish
+      Location:
+      - https://upload.wikimedia.org/wikipedia/en/thumb/fooooof.png
+      Content-Length:
+      - '0'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 08 Sep 2015 01:24:42 GMT
+      X-Varnish:
+      - '800279090'
+      Age:
+      - '0'
+      Via:
+      - 1.1 varnish
+      Connection:
+      - close
+      X-Cache:
+      - cp1072 frontend miss (0)
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Age, Date, Content-Length, Content-Range, X-Content-Duration, X-Cache, X-Varnish
+      Timing-Allow-Origin:
+      - "*"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: http://upload.wikimedia.org/wikipedia/en/thumb/fooooof.png
+  recorded_at: Tue, 08 Sep 2015 01:24:42 GMT
+- request:
+    method: get
+    uri: http://upload.wikimedia.org/wikipedia/en/thumb/not_here.png
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/2.4.2; +https://github.com/gjtorikian/html-proofer)
+  response:
+    status:
+      code: 301
+      message: TLS Redirect
+    headers:
+      Server:
+      - Varnish
+      Location:
+      - https://upload.wikimedia.org/wikipedia/en/thumb/not_here.png
+      Content-Length:
+      - '0'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 08 Sep 2015 01:24:42 GMT
+      X-Varnish:
+      - '612995440'
+      Age:
+      - '0'
+      Via:
+      - 1.1 varnish
+      Connection:
+      - close
+      X-Cache:
+      - cp1063 frontend miss (0)
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Age, Date, Content-Length, Content-Range, X-Content-Duration, X-Cache, X-Varnish
+      Timing-Allow-Origin:
+      - "*"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: http://upload.wikimedia.org/wikipedia/en/thumb/not_here.png
+  recorded_at: Tue, 08 Sep 2015 01:24:42 GMT
+- request:
+    method: head
+    uri: https://help.github.com/changing-author-info/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/2.4.2; +https://github.com/gjtorikian/html-proofer)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Content-Type:
+      - text/html; charset=utf-8
+      Last-Modified:
+      - Fri, 04 Sep 2015 18:26:39 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Expires:
+      - Tue, 08 Sep 2015 01:34:42 GMT
+      Cache-Control:
+      - max-age=600
+      Content-Length:
+      - '458'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 08 Sep 2015 01:24:42 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-sjc3125-SJC
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://help.github.com/changing-author-info/
+  recorded_at: Tue, 08 Sep 2015 01:24:42 GMT
+recorded_with: VCR 2.9.3

--- a/spec/html/proofer/links_spec.rb
+++ b/spec/html/proofer/links_spec.rb
@@ -367,4 +367,10 @@ describe 'Links test' do
     proofer = run_proofer(fixture)
     expect(proofer.failed_tests).to eq []
   end
+
+  it 'does not check links with parameters multiple times' do
+    fixture = "#{FIXTURES_DIR}/links/check_just_once.html"
+    proofer = run_proofer(fixture)
+    expect(proofer.external_urls.length).to eq 2
+  end
 end

--- a/spec/html/proofer/utils_spec.rb
+++ b/spec/html/proofer/utils_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
-describe HTML::Utils do
+describe HTML::Proofer::Utils do
   describe '::create_nokogiri' do
     it 'passes for a string' do
-      noko = HTML::Utils::create_nokogiri '<html lang="jp">'
+      noko = HTML::Proofer::Utils::create_nokogiri '<html lang="jp">'
       expect(noko.css('html').first['lang']).to eq 'jp'
     end
     it 'passes for a file' do
-      noko = HTML::Utils::create_nokogiri "#{FIXTURES_DIR}/utils/lang-jp.html"
+      noko = HTML::Proofer::Utils::create_nokogiri "#{FIXTURES_DIR}/utils/lang-jp.html"
       expect(noko.css('html').first['lang']).to eq 'jp'
     end
   end

--- a/spec/html/proofer_spec.rb
+++ b/spec/html/proofer_spec.rb
@@ -36,7 +36,7 @@ describe HTML::Proofer do
 
     describe 'sorting' do
       it 'understands sorting by path' do
-        output = send_proofer_output("#{FIXTURES_DIR}/sorting/path")
+        output = send_proofer_output("#{FIXTURES_DIR}/sorting/path", :verbosity => :info)
 
         expect(output.strip).to eq('''
 - spec/html/proofer/fixtures/sorting/path/multiple_issues.html
@@ -49,7 +49,7 @@ describe HTML::Proofer do
       end
 
       it 'understands sorting by issue' do
-        output = send_proofer_output("#{FIXTURES_DIR}/sorting/issue", :error_sort => :desc)
+        output = send_proofer_output("#{FIXTURES_DIR}/sorting/issue", :verbosity => :info, :error_sort => :desc)
         expect(output.strip).to eq('''
 - image ./gpl.png does not have an alt attribute
   *  spec/html/proofer/fixtures/sorting/issue/broken_image_one.html (line 1)
@@ -64,7 +64,7 @@ describe HTML::Proofer do
 
 
       it 'understands sorting by status' do
-        output = send_proofer_output("#{FIXTURES_DIR}/sorting/status", :typhoeus => { :followlocation => false }, :error_sort => :status)
+        output = send_proofer_output("#{FIXTURES_DIR}/sorting/status", :verbosity => :info, :typhoeus => { :followlocation => false }, :error_sort => :status)
         expect(output.gsub(/\s*$/, '')).to eq('''
 - -1
   *  spec/html/proofer/fixtures/sorting/status/broken_link.html: internally linking to nowhere.fooof, which does not exist (line 3)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,7 +34,7 @@ def capture_stderr(*)
 end
 
 def make_proofer(file, opts)
-  opts[:verbosity] = :fatal
+  opts[:verbosity] ||= :fatal
   HTML::Proofer.new(file, opts)
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require 'vcr'
 require_relative '../lib/html/proofer'
 
 FIXTURES_DIR = 'spec/html/proofer/fixtures'
+QUIET = true
 
 RSpec.configure do |config|
   # Use color in STDOUT
@@ -18,17 +19,21 @@ RSpec.configure do |config|
   config.order = :random
 end
 
+def quiet?
+  defined?(QUIET) && QUIET
+end
+
 def capture_stderr(*)
   original_stderr = $stderr
   original_stdout = $stdout
   $stderr = fake_err = StringIO.new
-  $stdout = fake_out = StringIO.new
+  $stdout = fake_out = StringIO.new if quiet?
   begin
     yield
   rescue RuntimeError
   ensure
     $stderr = original_stderr
-    $stdout = original_stdout
+    $stdout = original_stdout if quiet?
   end
   fake_err.string
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,12 +20,15 @@ end
 
 def capture_stderr(*)
   original_stderr = $stderr
+  original_stdout = $stdout
   $stderr = fake_err = StringIO.new
+  $stdout = fake_out = StringIO.new
   begin
     yield
   rescue RuntimeError
   ensure
     $stderr = original_stderr
+    $stdout = original_stdout
   end
   fake_err.string
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,6 @@ require 'vcr'
 require_relative '../lib/html/proofer'
 
 FIXTURES_DIR = 'spec/html/proofer/fixtures'
-QUIET = true
 
 RSpec.configure do |config|
   # Use color in STDOUT
@@ -19,26 +18,20 @@ RSpec.configure do |config|
   config.order = :random
 end
 
-def quiet?
-  defined?(QUIET) && QUIET
-end
-
 def capture_stderr(*)
   original_stderr = $stderr
-  original_stdout = $stdout
   $stderr = fake_err = StringIO.new
-  $stdout = fake_out = StringIO.new if quiet?
   begin
     yield
   rescue RuntimeError
   ensure
     $stderr = original_stderr
-    $stdout = original_stdout if quiet?
   end
   fake_err.string
 end
 
 def make_proofer(file, opts)
+  opts[:verbosity] = :fatal
   HTML::Proofer.new(file, opts)
 end
 


### PR DESCRIPTION
This loosens up the external URL checks for URLs with queries. For example:

``` html
<a href="https://github.com/contact?form%5Bsubject%5D=New+Assigned+Events">First</a>

<a href="https://github.com/contact?form%5Bsubject%5D=Organization+and+Team+Membership+APIs">Ignored</a>

<a href="https://github.com/contact#false?form%5Bsubject%5D=Organization+and+Team+Membership+APIs">Second, because of hash</a>

<a href="https://github.com/contact?form%5Bsubject%5D=Blah+and+blah+blah+APIs">Ignored</a>
```

It doesn't matter that `contact?form` has multiple values. The URL is essentially the same.

In this PR, we'll consider a URL with queries different if and only if it has different query parameters, not different query values.