### PR TITLE
Move query string check inline into UrlValidator

### DIFF
--- a/lib/html/proofer.rb
+++ b/lib/html/proofer.rb
@@ -22,7 +22,7 @@ module HTML
   class Proofer
     include HTML::Proofer::Utils
 
-    attr_reader :options, :typhoeus_opts, :hydra_opts, :parallel_opts, :validation_opts, :external_urls
+    attr_reader :options, :typhoeus_opts, :hydra_opts, :parallel_opts, :validation_opts, :external_urls, :iterable_external_urls
 
     TYPHOEUS_DEFAULTS = {
       :followlocation => true,
@@ -147,6 +147,7 @@ module HTML
     def validate_urls
       url_validator = HTML::Proofer::UrlValidator.new(logger, @external_urls, @options, @typhoeus_opts, @hydra_opts)
       @failed_tests.concat(url_validator.run)
+      @iterable_external_urls = url_validator.iterable_external_urls
     end
 
     def files

--- a/lib/html/proofer/check_runner.rb
+++ b/lib/html/proofer/check_runner.rb
@@ -24,7 +24,6 @@ module HTML
         @alt_ignores = @options[:alt_ignore]
         @empty_alt_ignore = @options[:empty_alt_ignore]
         @external_urls = {}
-        @external_domain_paths_with_queries = {}
       end
 
       def run
@@ -37,13 +36,7 @@ module HTML
 
       def add_to_external_urls(url, line)
         return if @external_urls[url]
-        uri = Addressable::URI.parse(url)
-
-        if uri.query.nil?
-          add_path_for_url(url)
-        else
-          new_url_query_values?(uri, url)
-        end
+        add_path_for_url(url)
       end
 
       def add_path_for_url(url)
@@ -52,26 +45,6 @@ module HTML
         else
           @external_urls[url] = [@path]
         end
-      end
-
-      def new_url_query_values?(uri, url)
-        queries = uri.query_values.keys.join('-')
-        domain_path = extract_domain_path(uri)
-        if @external_domain_paths_with_queries[domain_path].nil?
-          add_path_for_url(url)
-          # remember queries we've seen, ignore future ones
-          @external_domain_paths_with_queries[domain_path] = [queries]
-        else
-          # add queries we haven't seen
-          unless @external_domain_paths_with_queries[domain_path].include?(queries)
-            add_path_for_url(url)
-            @external_domain_paths_with_queries[domain_path] << queries
-          end
-        end
-      end
-
-      def extract_domain_path(uri)
-        uri.host + uri.path
       end
 
       def self.checks

--- a/lib/html/proofer/url_validator.rb
+++ b/lib/html/proofer/url_validator.rb
@@ -7,11 +7,12 @@ module HTML
     class UrlValidator
       include HTML::Proofer::Utils
 
-      attr_accessor :logger, :external_urls, :hydra
+      attr_accessor :logger, :external_urls, :iterable_external_urls, :hydra
 
       def initialize(logger, external_urls, options, typhoeus_opts, hydra_opts)
         @logger = logger
         @external_urls = external_urls
+        @iterable_external_urls = {}
         @failed_tests = []
         @options = options
         @hydra = Typhoeus::Hydra.new(hydra_opts)
@@ -20,8 +21,8 @@ module HTML
       end
 
       def run
-        external_urls = remove_query_values
-        external_link_checker(external_urls)
+        @iterable_external_urls = remove_query_values
+        external_link_checker(@iterable_external_urls)
         @failed_tests
       end
 

--- a/spec/html/proofer/links_spec.rb
+++ b/spec/html/proofer/links_spec.rb
@@ -371,6 +371,6 @@ describe 'Links test' do
   it 'does not check links with parameters multiple times' do
     fixture = "#{FIXTURES_DIR}/links/check_just_once.html"
     proofer = run_proofer(fixture)
-    expect(proofer.external_urls.length).to eq 2
+    expect(proofer.iterable_external_urls.length).to eq 2
   end
 end


### PR DESCRIPTION
It doesn't make sense to keep this functionality in CheckRunner, mostly because UrlValidator deals with *all* the URLs, whereas CheckRunner is picked up on every single file read.