### PR TITLE
Do not explode on error

### DIFF
--- a/lib/html/proofer/check_runner.rb
+++ b/lib/html/proofer/check_runner.rb
@@ -61,7 +61,7 @@ module HTML
       private
 
       def remove_ignored(html)
-        html.css('code, pre').each(&:unlink)
+        html.css('code, pre, tt').each(&:unlink)
         html
       end
     end

--- a/lib/html/proofer/checkable.rb
+++ b/lib/html/proofer/checkable.rb
@@ -11,7 +11,7 @@ module HTML
 
       def initialize(obj, check)
         obj.attributes.each_pair do |attribute, value|
-          instance_variable_set("@#{attribute.tr('-:', '_')}".to_sym, value.value)
+          instance_variable_set("@#{attribute.tr('-:.', '_')}".to_sym, value.value)
         end
 
         @text = obj.content

--- a/lib/html/proofer/checkable.rb
+++ b/lib/html/proofer/checkable.rb
@@ -39,7 +39,7 @@ module HTML
 
       def parts
         @parts ||= Addressable::URI.parse url
-      rescue URI::Error
+      rescue URI::Error, Addressable::URI::InvalidURIError
         @parts = nil
       end
 

--- a/spec/html/proofer/checkable_spec.rb
+++ b/spec/html/proofer/checkable_spec.rb
@@ -44,4 +44,11 @@ describe HTML::Proofer::Checkable do
       expect(checkable.ignore?).to eq true
     end
   end
+  describe 'ivar setting' do
+    it 'does not explode if given a bad attribute' do
+      broken_attribute = "#{FIXTURES_DIR}/html/invalid_attribute.html"
+      proofer = run_proofer(broken_attribute)
+      expect(proofer.failed_tests.length).to eq 0
+    end
+  end
 end

--- a/spec/html/proofer/fixtures/html/invalid_attribute.html
+++ b/spec/html/proofer/fixtures/html/invalid_attribute.html
@@ -1,0 +1,7 @@
+<div class="show-photo-single debug-container">
+       <a class="fancybox" rel="photos" href="invalid_tag.html" title="Cast and Crew shot. From back left:">
+         <span  alt="Show photo" title Cast and Crew shot. From back left >
+         <div class="debug-abs-bottom-left" data-debug-toggle title="Photo type">photo</div>
+         <div class="debug-abs-top-left" data-debug-toggle title="Photo image">pillowman_crew.jpg</div>
+       </a>
+     </div>

--- a/spec/html/proofer/fixtures/links/bad_external_links.html
+++ b/spec/html/proofer/fixtures/links/bad_external_links.html
@@ -1,0 +1,13 @@
+<html>
+
+<body>
+
+  <a href="http://127.0.0.1:____">Horrible link!</a>
+
+	<p>Blah blah blah. <a href="http://www.google.com">Working link!</a></p>
+
+<a href="http://www.asdo3IRJ395295jsingrkrg4.com">broken link!</a>
+
+</body>
+
+</html>

--- a/spec/html/proofer/fixtures/vcr_cassettes/links/bad_external_links_html.yml
+++ b/spec/html/proofer/fixtures/vcr_cassettes/links/bad_external_links_html.yml
@@ -1,0 +1,178 @@
+---
+http_interactions:
+- request:
+    method: head
+    uri: http://127.0.0.1xxxx/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/2.5.1; +https://github.com/gjtorikian/html-proofer)
+  response:
+    status:
+      code: 0
+      message: 
+    headers: {}
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+    adapter_metadata:
+      effective_url: http://127.0.0.1xxxx/
+  recorded_at: Sun, 04 Oct 2015 23:04:34 GMT
+- request:
+    method: get
+    uri: http://127.0.0.1xxxx/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/2.5.1; +https://github.com/gjtorikian/html-proofer)
+  response:
+    status:
+      code: 0
+      message: 
+    headers: {}
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+    adapter_metadata:
+      effective_url: http://127.0.0.1xxxx/
+  recorded_at: Sun, 04 Oct 2015 23:04:34 GMT
+- request:
+    method: head
+    uri: http://www.google.com/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/2.5.1; +https://github.com/gjtorikian/html-proofer)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 04 Oct 2015 23:04:34 GMT
+      Expires:
+      - "-1"
+      Cache-Control:
+      - private, max-age=0
+      Content-Type:
+      - text/html; charset=UTF-8
+      P3P:
+      - CP="This is not a P3P policy! See http://www.google.com/support/accounts/bin/answer.py?hl=en&answer=151657
+        for more info."
+      Server:
+      - gws
+      X-XSS-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      Set-Cookie:
+      - PREF=ID=1111111111111111:FF=0:TM=1443999873:LM=1443999874:V=1:S=UI1v6PzHTMb9B4m4;
+        expires=Thu, 31-Dec-2015 16:02:17 GMT; path=/; domain=.google.com
+      - NID=72=SCWqTvvw6F5cbb42I2KGXYembydmQSxhDtIoxL3s2SIq_GEzq0sJ6Z9NZ5FkViUYP7SFVGOfnsVddTCkeUw0Of72smOLtUz3iM5W9pMbTtVMOXG4KEuR1Da0LFzQdTGYNGynvrlNvl03YHid8y7EdRONetIIDkUd;
+        expires=Mon, 04-Apr-2016 23:04:34 GMT; path=/; domain=.google.com; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Accept-Ranges:
+      - none
+      Vary:
+      - Accept-Encoding
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: http://www.google.com/
+  recorded_at: Sun, 04 Oct 2015 23:04:34 GMT
+- request:
+    method: head
+    uri: http://www.asdo3irj395295jsingrkrg4.com/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/2.5.1; +https://github.com/gjtorikian/html-proofer)
+  response:
+    status:
+      code: 0
+      message: 
+    headers: {}
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+    adapter_metadata:
+      effective_url: http://www.asdo3irj395295jsingrkrg4.com/
+  recorded_at: Sun, 04 Oct 2015 23:04:34 GMT
+- request:
+    method: get
+    uri: http://www.asdo3irj395295jsingrkrg4.com/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/2.5.1; +https://github.com/gjtorikian/html-proofer)
+  response:
+    status:
+      code: 0
+      message: 
+    headers: {}
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+    adapter_metadata:
+      effective_url: http://www.asdo3irj395295jsingrkrg4.com/
+  recorded_at: Sun, 04 Oct 2015 23:04:34 GMT
+- request:
+    method: head
+    uri: http://xn--127-th33b.0.0.1/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/2.5.1; +https://github.com/gjtorikian/html-proofer)
+  response:
+    status:
+      code: 0
+      message: 
+    headers: {}
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+    adapter_metadata:
+      effective_url: http://xn--127-th33b.0.0.1/
+  recorded_at: Sun, 04 Oct 2015 23:08:28 GMT
+- request:
+    method: get
+    uri: http://xn--127-th33b.0.0.1/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/2.5.1; +https://github.com/gjtorikian/html-proofer)
+  response:
+    status:
+      code: 0
+      message: 
+    headers: {}
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+    adapter_metadata:
+      effective_url: http://xn--127-th33b.0.0.1/
+  recorded_at: Sun, 04 Oct 2015 23:08:28 GMT
+recorded_with: VCR 2.9.3

--- a/spec/html/proofer/fixtures/vcr_cassettes/www_github_com_http_/127_0_0_1_____.yml
+++ b/spec/html/proofer/fixtures/vcr_cassettes/www_github_com_http_/127_0_0_1_____.yml
@@ -1,0 +1,116 @@
+---
+http_interactions:
+- request:
+    method: head
+    uri: ''
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/2.5.1; +https://github.com/gjtorikian/html-proofer)
+  response:
+    status:
+      code: 0
+      message: 
+    headers: {}
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+    adapter_metadata:
+      effective_url: ''
+  recorded_at: Sun, 04 Oct 2015 23:34:01 GMT
+- request:
+    method: get
+    uri: ''
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/2.5.1; +https://github.com/gjtorikian/html-proofer)
+  response:
+    status:
+      code: 0
+      message: 
+    headers: {}
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+    adapter_metadata:
+      effective_url: ''
+  recorded_at: Sun, 04 Oct 2015 23:34:01 GMT
+- request:
+    method: head
+    uri: www.github.com
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/2.5.1; +https://github.com/gjtorikian/html-proofer)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Sun, 04 Oct 2015 23:34:03 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Status:
+      - 200 OK
+      Content-Security-Policy:
+      - 'default-src *; script-src assets-cdn.github.com collector-cdn.github.com;
+        object-src assets-cdn.github.com; style-src ''self'' ''unsafe-inline'' ''unsafe-eval''
+        assets-cdn.github.com; img-src ''self'' data: assets-cdn.github.com identicons.github.com
+        www.google-analytics.com checkout.paypal.com collector.githubapp.com *.githubusercontent.com
+        *.gravatar.com *.wp.com; media-src ''none''; frame-src ''self'' render.githubusercontent.com
+        gist.github.com www.youtube.com player.vimeo.com checkout.paypal.com; font-src
+        assets-cdn.github.com; connect-src ''self'' live.github.com wss://live.github.com
+        uploads.github.com status.github.com api.github.com www.google-analytics.com
+        api.braintreegateway.com client-analytics.braintreegateway.com github-cloud.s3.amazonaws.com;
+        base-uri ''self''; form-action ''self'' github.com gist.github.com'
+      Public-Key-Pins:
+      - max-age=300; pin-sha256="WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18="; pin-sha256="JbQbUG5JMJUoI6brnx0x3vZF6jilxsapbXGVfjhN8Fg=";
+        includeSubDomains
+      Cache-Control:
+      - no-cache
+      Vary:
+      - X-PJAX
+      - Accept-Encoding
+      X-UA-Compatible:
+      - IE=Edge,chrome=1
+      Set-Cookie:
+      - logged_in=no; domain=.github.com; path=/; expires=Thu, 04 Oct 2035 23:34:03
+        -0000; secure; HttpOnly
+      - _gh_sess=eyJzZXNzaW9uX2lkIjoiOGVkYTJmN2MwZmQzNmFhNTdjODAxYmY3Y2M2NDNkYmIiLCJfY3NyZl90b2tlbiI6IkgzNWp6L1lQRXI2Vno3SWsyNmFSR1duOTlIVTVGNUFnUEtBaWlrTU9DNms9In0%3D--e98bd9290c51cded11cbf38f8ad8aeea18f01d64;
+        path=/; secure; HttpOnly
+      X-Request-Id:
+      - a10b4c5e795d618fa9549d4813a678e0
+      X-Runtime:
+      - '0.009348'
+      X-GitHub-Request-Id:
+      - 490F8465:108B:12D9C84A:5611B76B
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - deny
+      X-Served-By:
+      - 9835a984a05caa405eb61faaa1546741
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://github.com/
+  recorded_at: Sun, 04 Oct 2015 23:34:03 GMT
+recorded_with: VCR 2.9.3

--- a/spec/html/proofer/links_spec.rb
+++ b/spec/html/proofer/links_spec.rb
@@ -374,10 +374,15 @@ describe 'Links test' do
     expect(proofer.iterable_external_urls.length).to eq 2
   end
 
-  it 'does not explode on bad external links' do
+  it 'does not explode on bad external links in files' do
     fixture = "#{FIXTURES_DIR}/links/bad_external_links.html"
     proofer = run_proofer(fixture)
     expect(proofer.failed_tests.length).to eq 2
+    expect(proofer.failed_tests.first).to match(/is an invalid URL/)
+  end
+
+  it 'does not explode on bad external links in arrays' do
+    proofer = run_proofer(['www.github.com', 'http://127.0.0.1:____'])
     expect(proofer.failed_tests.first).to match(/is an invalid URL/)
   end
 end

--- a/spec/html/proofer/links_spec.rb
+++ b/spec/html/proofer/links_spec.rb
@@ -373,4 +373,11 @@ describe 'Links test' do
     proofer = run_proofer(fixture)
     expect(proofer.iterable_external_urls.length).to eq 2
   end
+
+  it 'does not explode on bad external links' do
+    fixture = "#{FIXTURES_DIR}/links/bad_external_links.html"
+    proofer = run_proofer(fixture)
+    expect(proofer.failed_tests.length).to eq 2
+    expect(proofer.failed_tests.first).to match(/is an invalid URL/)
+  end
 end


### PR DESCRIPTION
Closes https://github.com/gjtorikian/html-proofer/issues/248 -- invalid URLs should be reported, but not raise exceptions. 

Closes https://github.com/gjtorikian/html-proofer/issues/245 by allowing `.` to be escaped.