### PR TITLE
Don't bundle everything up in the gem

### DIFF
--- a/bin/htmlproof
+++ b/bin/htmlproof
@@ -16,7 +16,7 @@ def to_regex?(item)
 end
 
 Mercenary.program(:htmlproof) do |p|
-  p.version Gem::Specification.load(File.join(File.dirname(__FILE__), '..', 'html-proofer.gemspec')).version
+  p.version HTML::Proofer::VERSION
   p.description %(Test your rendered HTML files to make sure they're accurate.)
   p.syntax 'htmlproof PATH [options]'
 

--- a/html-proofer.gemspec
+++ b/html-proofer.gemspec
@@ -12,7 +12,9 @@ Gem::Specification.new do |gem|
   gem.homepage      = 'https://github.com/gjtorikian/html-proofer'
   gem.license       = 'MIT'
   gem.executables   = ['htmlproof']
-  gem.files         = `git ls-files -z`.split("\x0")
+  all_files         = `git ls-files -z`.split("\x0")
+  gem.files         = all_files.grep(%r{^(bin|lib)/})
+  gem.executables   = all_files.grep(%r{^bin/}) { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(spec)/})
   gem.require_paths = ['lib']
 


### PR DESCRIPTION
This fixes https://github.com/gjtorikian/html-proofer/issues/258, in that the built gem should only include the files in `lib` and `bin`, thus omitting the Git check on every `htmlproof` run. 