### PR TITLE
Added --allow-hash-href option

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ The `HTML::Proofer` constructor takes an optional hash of additional options:
 
 | Option | Description | Default |
 | :----- | :---------- | :------ |
+| `allow_hash_href` | If `true`, ignores the `href` `#`. | `false` |
 | `alt_ignore` | An array of Strings or RegExps containing `img`s whose missing `alt` tags are safe to ignore. | `[]` |
 | `empty_alt_ignore` | If `true`, ignores images with empty alt tags. | `false` |
 | `check_external_hash` | Checks whether external hashes exist (even if the website exists). This slows the checker down. | `false` |

--- a/bin/htmlproof
+++ b/bin/htmlproof
@@ -22,6 +22,7 @@ Mercenary.program(:htmlproof) do |p|
 
   p.description 'Runs the HTML-Proofer suite on the files in PATH. For more details, see the README.'
 
+  p.option 'allow_hash_href', '--allow-hash-href', 'Allows the `#` `href`.'
   p.option 'as_links', '--as-links', 'Assumes that `PATH` is a comma-separated array of links to check.'
   p.option 'alt_ignore', '--alt-ignore image1,[image2,...]', Array, 'Comma-separated list of Strings or RegExps containing `img`s whose missing `alt` tags are safe to ignore'
   p.option 'empty_alt_ignore', '--empty-alt-ignore', 'Ignores images with empty alt tags.'

--- a/lib/html/proofer.rb
+++ b/lib/html/proofer.rb
@@ -46,6 +46,7 @@ module HTML
         :check_favicon => false,
         :href_swap => [],
         :href_ignore => [],
+        :allow_hash_href => false,
         :file_ignore => [],
         :url_ignore => [],
         :check_external_hash => false,

--- a/lib/html/proofer/check_runner.rb
+++ b/lib/html/proofer/check_runner.rb
@@ -7,7 +7,7 @@ module HTML
 
       attr_reader :issues, :src, :path, :options, :typhoeus_opts, :hydra_opts, :parallel_opts, \
                   :validation_opts, :external_urls, :href_ignores, :url_ignores, :alt_ignores, \
-                  :empty_alt_ignore
+                  :empty_alt_ignore, :allow_hash_href
 
       def initialize(src, path, html, options, typhoeus_opts, hydra_opts, parallel_opts, validation_opts)
         @src    = src
@@ -23,6 +23,7 @@ module HTML
         @url_ignores = @options[:url_ignore]
         @alt_ignores = @options[:alt_ignore]
         @empty_alt_ignore = @options[:empty_alt_ignore]
+        @allow_hash_href = @options[:allow_hash_href]
         @external_urls = {}
       end
 

--- a/lib/html/proofer/checkable.rb
+++ b/lib/html/proofer/checkable.rb
@@ -90,6 +90,10 @@ module HTML
         @check.empty_alt_ignore
       end
 
+      def allow_hash_href?
+        @check.allow_hash_href
+      end
+
       # path is external to the file
       def external?
         !internal?

--- a/lib/html/proofer/checks/links.rb
+++ b/lib/html/proofer/checks/links.rb
@@ -32,6 +32,7 @@ class LinkCheck < ::HTML::Proofer::CheckRunner
       next if link.ignore?
       next if link.href =~ /^javascript:/ # can't put this in ignore? because the URI does not parse
       next if link.placeholder?
+      next if link.allow_hash_href? && link.href == '#'
 
       # is it even a valid URL?
       unless link.valid?

--- a/spec/html/proofer/command_spec.rb
+++ b/spec/html/proofer/command_spec.rb
@@ -85,4 +85,10 @@ describe 'Command test' do
     output = make_bin('--empty-alt-ignore', broken)
     expect(output).to match('successfully')
   end
+
+  it 'works with allow-hash-href' do
+    broken = "#{FIXTURES_DIR}/html/href_hash.html"
+    output = make_bin('--allow-hash-href', broken)
+    expect(output).to match('successfully')
+  end
 end

--- a/spec/html/proofer/fixtures/links/hash_href.html
+++ b/spec/html/proofer/fixtures/links/hash_href.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+  <a href="#"></a>
+</body>
+</html>

--- a/spec/html/proofer/links_spec.rb
+++ b/spec/html/proofer/links_spec.rb
@@ -397,4 +397,17 @@ describe 'Links test' do
     proofer = run_proofer(non_https, { :enforce_https => true } )
     expect(proofer.failed_tests.first).to match(/ben.balter.com is not an HTTPS link/)
   end
+
+  it 'passes for hash href when asked' do
+    hash_href = "#{FIXTURES_DIR}/links/hash_href.html"
+    proofer = run_proofer(hash_href, { :allow_hash_href => true })
+    expect(proofer.failed_tests.length).to eq 0
+  end
+
+  it 'fails for hash href when not asked' do
+    hash_href = "#{FIXTURES_DIR}/links/hash_href.html"
+    proofer = run_proofer(hash_href)
+    expect(proofer.failed_tests.first).to match(/linking to internal hash # that does not exist/)
+  end
+
 end


### PR DESCRIPTION
Fixes #255 by adding a more intuitive option to allow the `href` `#`.
This option, `--allow-hash-href`, is equivalent to `--href-ignore '#'`.
Its Ruby option is `allow_hash_href`, which should be a boolean and
defaults to `false`.