### PR TITLE
Add support for <base> tags

### DIFF
--- a/lib/html/proofer/check_runner.rb
+++ b/lib/html/proofer/check_runner.rb
@@ -26,6 +26,11 @@ module HTML
         @external_urls = {}
       end
 
+      def base
+        return @base if defined?(@base)
+        @base = @html.at_css("base")
+      end
+
       def run
         fail NotImplementedError, 'HTML::Proofer::CheckRunner subclasses must implement #run'
       end

--- a/lib/html/proofer/checkable.rb
+++ b/lib/html/proofer/checkable.rb
@@ -9,7 +9,7 @@ module HTML
 
       attr_reader :line
 
-      def initialize(obj, check, base = nil)
+      def initialize(obj, check)
         obj.attributes.each_pair do |attribute, value|
           instance_variable_set("@#{attribute.tr('-:.', '_')}".to_sym, value.value)
         end
@@ -24,17 +24,17 @@ module HTML
           @href = swap(@href, @check.options[:href_swap])
         end
 
-        if @href && base
-          @href = Addressable::URI.join(base.attr("href"), @href).to_s
-        end
-
         # fix up missing protocols
         @href.insert 0, 'http:' if @href =~ %r{^//}
         @src.insert 0, 'http:' if @src =~ %r{^//}
       end
 
       def url
-        @src || @srcset || @href || ''
+        url = @src || @srcset || @href || ''
+        if @check.base
+          url = Addressable::URI.join(@check.base.attr("href"), url).to_s
+        end
+        url
       end
 
       def valid?

--- a/lib/html/proofer/checkable.rb
+++ b/lib/html/proofer/checkable.rb
@@ -9,7 +9,7 @@ module HTML
 
       attr_reader :line
 
-      def initialize(obj, check)
+      def initialize(obj, check, base = nil)
         obj.attributes.each_pair do |attribute, value|
           instance_variable_set("@#{attribute.tr('-:.', '_')}".to_sym, value.value)
         end
@@ -22,6 +22,10 @@ module HTML
 
         if @href && @check.options[:href_swap]
           @href = swap(@href, @check.options[:href_swap])
+        end
+
+        if @href && base
+          @href = Addressable::URI.join(base.attr("href"), @href).to_s
         end
 
         # fix up missing protocols

--- a/lib/html/proofer/checks/links.rb
+++ b/lib/html/proofer/checks/links.rb
@@ -25,10 +25,8 @@ class LinkCheck < ::HTML::Proofer::CheckRunner
   include HTML::Proofer::Utils
 
   def run
-    base = @html.at_css("base")
-
     @html.css('a, link').each do |node|
-      link = LinkCheckable.new(node, self, base)
+      link = LinkCheckable.new(node, self)
       line = node.line
 
       next if link.ignore?

--- a/lib/html/proofer/checks/links.rb
+++ b/lib/html/proofer/checks/links.rb
@@ -25,8 +25,10 @@ class LinkCheck < ::HTML::Proofer::CheckRunner
   include HTML::Proofer::Utils
 
   def run
+    base = @html.at_css("base")
+
     @html.css('a, link').each do |node|
-      link = LinkCheckable.new(node, self)
+      link = LinkCheckable.new(node, self, base)
       line = node.line
 
       next if link.ignore?

--- a/spec/html/proofer/fixtures/images/relativeWithBase.html
+++ b/spec/html/proofer/fixtures/images/relativeWithBase.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <base href="/links/">
+  </head>
+  <body>
+    <img alt="relative to base" src="gpl.png"/>
+    <img alt="subdirectory relative to base" src="folder/assets/barrel.png"/>
+    <img alt="relative to base sibling" src="../images/gpl.png"/>
+    <img alt="relative to root" src="/images/gpl.png"/>
+  </body>
+</html>

--- a/spec/html/proofer/fixtures/links/relativeLinksWithBase.html
+++ b/spec/html/proofer/fixtures/links/relativeLinksWithBase.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <base href="folder/">
+  </head>
+  <body>
+    <a href="/anchors_in_pre.html">Relative to root</a>
+    <a href="anchorLink.html">Relative to base</a>
+    <a href="../relativeLinks.html">Back relative to base</a>
+  </body>
+</html>

--- a/spec/html/proofer/images_spec.rb
+++ b/spec/html/proofer/images_spec.rb
@@ -72,6 +72,12 @@ describe 'Images test' do
     expect(proofer.failed_tests).to eq []
   end
 
+  it 'properly checks relative images with base' do
+    relativeImages = "#{FIXTURES_DIR}/images/relativeWithBase.html"
+    proofer = run_proofer(relativeImages)
+    expect(proofer.failed_tests).to eq []
+  end
+
   it 'properly ignores data URI images' do
     dataURIImage = "#{FIXTURES_DIR}/images/workingDataURIImage.html"
     proofer = run_proofer(dataURIImage)

--- a/spec/html/proofer/links_spec.rb
+++ b/spec/html/proofer/links_spec.rb
@@ -397,4 +397,10 @@ describe 'Links test' do
     proofer = run_proofer(non_https, { :enforce_https => true } )
     expect(proofer.failed_tests.first).to match(/ben.balter.com is not an HTTPS link/)
   end
+
+  it 'passes for relative links with a base' do
+    relativeLinks = "#{FIXTURES_DIR}/links/relativeLinksWithBase.html"
+    proofer = run_proofer(relativeLinks)
+    expect(proofer.failed_tests).to eq []
+  end
 end


### PR DESCRIPTION
From [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base)

> The **HTML `<base>` element** specifies the base URL to use for all relative URLs contained within a document.

This adds support for the base tag for links and images. For some reason the image tests are failing and I'm having some trouble figuring out why.

Fixes #166 