### PR TITLE
Set `max_concurrency` to `50`

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ This sets `HTML::Proofer`'s extensions to use _.htm_, gives Typhoeus a configura
 
 You can similarly pass in a `:hydra` option with a hash configuration for Hydra.
 
-The default value is `typhoeus => { :followlocation => true }`.
+The default value is `{ :typhoeus => { :followlocation => true }, :hydra => { :max_concurrency => 50 } }`.
 
 ### Configuring Parallel
 

--- a/lib/html/proofer.rb
+++ b/lib/html/proofer.rb
@@ -31,6 +31,10 @@ module HTML
       }
     }
 
+    HYDRA_DEFAULTS = {
+      :max_concurrency => 50
+    }
+
     def initialize(src, opts = {})
       @src = src
 
@@ -65,7 +69,7 @@ module HTML
       @typhoeus_opts = TYPHOEUS_DEFAULTS.merge(opts[:typhoeus] || {})
       opts.delete(:typhoeus)
 
-      @hydra_opts = opts[:hydra] || {}
+      @hydra_opts = HYDRA_DEFAULTS.merge(opts[:hydra] || {})
       opts.delete(:hydra)
 
       # fall back to parallel defaults


### PR DESCRIPTION
It appears that on OS X, the default concurrency of 200 simply stops functioning after some time. The [Typhoeus docs even note](https://github.com/typhoeus/typhoeus/tree/c624a57477c07f32d48154ad5a656f699f4db13e#specifying-max-concurrency) this:

> Things will get flakey if you try to make too many requests at the same time. 

Setting a default limit of 50 slows things down a bit, but results in more accurate results.

Closes https://github.com/gjtorikian/html-proofer/issues/253