### PR TITLE
Clean content before parsing with Nokogiri

### DIFF
--- a/lib/html/proofer/utils.rb
+++ b/lib/html/proofer/utils.rb
@@ -33,9 +33,8 @@ module HTML
       # solution from http://git.io/vBYUi
       def clean_content(string)
         matches = string.scan(%r{<url>http(?:s)?://([^<]+)<\/url>}i) +
-                  string.scan(%r{"http(?:s)?://([^"]+)"}i) +
-                  string.scan(%r{\shttp(?:s)?://([^\s]+)\s}i) +
-                  string.scan(%r{window.open\(['"]http(?:s)?://([^\s]+)\s}i)
+                  string.scan(%r{http(?:s)?://([^>]+)}i) +
+                  string.scan(%r{window.open\(['"]http(?:s)?://([^>]+)}i)
 
         matches.flatten.each do |url|
           escaped_url = url.gsub(/&(?!amp;)/, '&amp;')

--- a/lib/html/proofer/utils.rb
+++ b/lib/html/proofer/utils.rb
@@ -16,7 +16,7 @@ module HTML
           content = path
         end
 
-        Nokogiri::HTML(content)
+        Nokogiri::HTML(clean_content(content))
       end
       module_function :create_nokogiri
 
@@ -27,6 +27,24 @@ module HTML
         href
       end
       module_function :swap
+
+      # address a problem with Nokogiri's parsing URL entities
+      # problem from http://git.io/vBYU1
+      # solution from http://git.io/vBYUi
+      def clean_content(string)
+        matches = string.scan(%r{<url>http(?:s)?://([^<]+)<\/url>}i) +
+                  string.scan(%r{"http(?:s)?://([^"]+)"}i) +
+                  string.scan(%r{\shttp(?:s)?://([^\s]+)\s}i) +
+                  string.scan(%r{window.open\(['"]http(?:s)?://([^\s]+)\s}i)
+
+        matches.flatten.each do |url|
+          escaped_url = url.gsub(/&(?!amp;)/, '&amp;')
+          escaped_url = escaped_url.gsub(%r{/}, '&#47;')
+          string.gsub!(url, escaped_url)
+        end
+        string
+      end
+      module_function :clean_content
     end
   end
 end

--- a/spec/html/proofer/fixtures/html/weird_iframe.html
+++ b/spec/html/proofer/fixtures/html/weird_iframe.html
@@ -1,0 +1,1 @@
+<iframe frameborder="0" style="border:0" src="https://www.google.com/maps/embed/v1/place?q=1035%20Market%20Street%2C%20Suite%20550%20San%20Francisco%2C%20CA%2094103&key=R-E-D-A-C-T-E-D"></iframe>

--- a/spec/html/proofer/fixtures/html/weird_onclick.html
+++ b/spec/html/proofer/fixtures/html/weird_onclick.html
@@ -1,0 +1,1 @@
+<a href="http://www.google.com" onClick="window.open('https://calendar.google.com/calendar/embed?src=o3uckm13gkcc5tu4u3846ik0pc%40group.calendar.google.com&ctz=America/Los_Angeles','Team Calendar','')">

--- a/spec/html/proofer/fixtures/vcr_cassettes/html/weird_onclick_html_check_html_true_.yml
+++ b/spec/html/proofer/fixtures/vcr_cassettes/html/weird_onclick_html_check_html_true_.yml
@@ -1,0 +1,52 @@
+---
+http_interactions:
+- request:
+    method: head
+    uri: http://www.google.com/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/2.5.2; +https://github.com/gjtorikian/html-proofer)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 24 Nov 2015 04:37:51 GMT
+      Expires:
+      - "-1"
+      Cache-Control:
+      - private, max-age=0
+      Content-Type:
+      - text/html; charset=UTF-8
+      P3P:
+      - CP="This is not a P3P policy! See http://www.google.com/support/accounts/bin/answer.py?hl=en&answer=151657
+        for more info."
+      Server:
+      - gws
+      X-XSS-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      Set-Cookie:
+      - PREF=ID=1111111111111111:FF=0:TM=1448339871:LM=1448339871:V=1:S=GN9uXSJgDAKheFqG;
+        expires=Thu, 31-Dec-2015 16:02:17 GMT; path=/; domain=.google.com
+      - NID=73=vRBSRItetlmHucCfyNLq8DQXVPuX-N9eYvqJKBz3qUOiBkRq3YZ_lluCcu26uhnByqZa0AuXwmHDqv3CRwp4kI3I5KGghW-aUCA7_B-zCLsiIosKeCyD7KvHN3TEgSAP8_QlhzzimlJRKMdC4mnSZJR0LI1iSosdAwXn-XVYKj_10WSBL1CzAvuHhc5uSGLqOw;
+        expires=Wed, 25-May-2016 04:37:51 GMT; path=/; domain=.google.com; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Accept-Ranges:
+      - none
+      Vary:
+      - Accept-Encoding
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: http://www.google.com/
+  recorded_at: Tue, 24 Nov 2015 04:37:51 GMT
+recorded_with: VCR 2.9.3

--- a/spec/html/proofer/html_spec.rb
+++ b/spec/html/proofer/html_spec.rb
@@ -61,4 +61,18 @@ describe 'Html test' do
     proofer = run_proofer(ignorableScript, opts)
     expect(proofer.failed_tests).to eq []
   end
+
+  it 'does not fail for weird iframe sources' do
+    opts = { :check_html => true }
+    weird_iframe = "#{FIXTURES_DIR}/html/weird_iframe.html"
+    proofer = run_proofer(weird_iframe, opts)
+    expect(proofer.failed_tests).to eq []
+  end
+
+  it 'does not fail for weird onclick sources' do
+    opts = { :check_html => true }
+    weird_onclick = "#{FIXTURES_DIR}/html/weird_onclick.html"
+    proofer = run_proofer(weird_onclick, opts)
+    expect(proofer.failed_tests).to eq []
+  end
 end


### PR DESCRIPTION
Apparently, unescaped forward slashes or ampersands will cause Nokogiri to break. In these cases, it's best to just rewrite the content so that Nokogiri is happy.

I thought about performing this rewrite for only HTML validation cases, but it felt better to just always do a clean.

Closes https://github.com/gjtorikian/html-proofer/issues/267.