### PR TITLE
Allow HTML5 anchors to not need `href`

### DIFF
--- a/lib/html/proofer/checks/links.rb
+++ b/lib/html/proofer/checks/links.rb
@@ -44,6 +44,8 @@ class LinkCheck < ::HTML::Proofer::CheckRunner
 
       # is there even a href?
       if link.missing_href?
+        # HTML5 allows dropping the href: http://git.io/vBX0z
+        next if @html.internal_subset.name == 'html' && @html.internal_subset.external_id.nil?
         add_issue('anchor has no href attribute', line)
         next
       end

--- a/spec/html/proofer/fixtures/links/blank_href_html4.html
+++ b/spec/html/proofer/fixtures/links/blank_href_html4.html
@@ -1,0 +1,7 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
+            "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<body>
+  <a>Missing href.</a>
+</body>
+</html>

--- a/spec/html/proofer/fixtures/links/blank_href_html5.html
+++ b/spec/html/proofer/fixtures/links/blank_href_html5.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+  <a>Missing href.</a>
+</body>
+</html>

--- a/spec/html/proofer/fixtures/links/blank_href_htmlunknown.html
+++ b/spec/html/proofer/fixtures/links/blank_href_htmlunknown.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+  <a>Missing href.</a>
+</body>
+</html>

--- a/spec/html/proofer/links_spec.rb
+++ b/spec/html/proofer/links_spec.rb
@@ -415,4 +415,20 @@ describe 'Links test' do
     proofer = run_proofer(hash_href)
     expect(proofer.failed_tests.first).to match(/response code 0/)
   end
+
+  it 'does not expect href for anchors in HTML5' do
+    missing_href = "#{FIXTURES_DIR}/links/blank_href_html5.html"
+    proofer = run_proofer(missing_href)
+    expect(proofer.failed_tests).to eq []
+  end
+
+  it 'does expect href for anchors in non-HTML5' do
+    missing_href = "#{FIXTURES_DIR}/links/blank_href_html4.html"
+    proofer = run_proofer(missing_href)
+    expect(proofer.failed_tests.length).to eq 1
+
+    missing_href = "#{FIXTURES_DIR}/links/blank_href_htmlunknown.html"
+    proofer = run_proofer(missing_href)
+    expect(proofer.failed_tests.length).to eq 1
+  end
 end


### PR DESCRIPTION
Closes https://github.com/gjtorikian/html-proofer/issues/254.