### PR TITLE
Unify configuration between README and executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,13 +156,13 @@ The `HTML::Proofer` constructor takes an optional hash of additional options:
 | :----- | :---------- | :------ |
 | `allow_hash_href` | If `true`, ignores the `href` `#`. | `false` |
 | `alt_ignore` | An array of Strings or RegExps containing `img`s whose missing `alt` tags are safe to ignore. | `[]` |
-| `empty_alt_ignore` | If `true`, ignores images with empty alt tags. | `false` |
 | `check_external_hash` | Checks whether external hashes exist (even if the website exists). This slows the checker down. | `false` |
 | `check_favicon` | Enables the favicon checker. | `false` |
 | `check_html` | Enables HTML validation errors from Nokogiri | `false` |
 |`checks_to_ignore`| An array of Strings indicating which checks you'd like to not perform. | `[]`
 | `directory_index_file` | Sets the file to look for when a link refers to a directory. | `index.html` |
 | `disable_external` | If `true`, does not run the external link checker, which can take a lot of time. | `false` |
+| `empty_alt_ignore` | If `true`, ignores images with empty alt tags. | `false` |
 | `enforce_https` | Fails a link if it's not marked as `https`. | `false` |
 | `error_sort` | Defines the sort order for error output. Can be `:path`, `:desc`, or `:status`. | `:path`
 | `ext` | The extension of your HTML files including the dot. | `.html`

--- a/bin/htmlproof
+++ b/bin/htmlproof
@@ -5,7 +5,6 @@ $LOAD_PATH.unshift File.join(File.dirname(__FILE__), *%w( .. lib ))
 
 require 'html/proofer'
 require 'mercenary'
-require 'rubygems'
 
 def to_regex?(item)
   if item.start_with?('/') && item.end_with?('/')
@@ -22,26 +21,26 @@ Mercenary.program(:htmlproof) do |p|
 
   p.description 'Runs the HTML-Proofer suite on the files in PATH. For more details, see the README.'
 
-  p.option 'allow_hash_href', '--allow-hash-href', 'Allows the `#` `href`.'
+  p.option 'allow_hash_href', '--allow-hash-href', 'If `true`, ignores the `href` `#`'
   p.option 'as_links', '--as-links', 'Assumes that `PATH` is a comma-separated array of links to check.'
-  p.option 'alt_ignore', '--alt-ignore image1,[image2,...]', Array, 'Comma-separated list of Strings or RegExps containing `img`s whose missing `alt` tags are safe to ignore'
-  p.option 'empty_alt_ignore', '--empty-alt-ignore', 'Ignores images with empty alt tags.'
+  p.option 'alt_ignore', '--alt-ignore image1,[image2,...]', Array, 'A comma-separated list of Strings or RegExps containing `img`s whose missing `alt` tags are safe to ignore'
   p.option 'checks_to_ignore', '--checks-to-ignore check1,[check2,...]', Array, ' An array of Strings indicating which checks you\'d like to not perform.'
   p.option 'check_external_hash', '--check-external-hash', 'Checks whether external hashes exist (even if the website exists). This slows the checker down (default: `false`).'
   p.option 'check_favicon', '--check-favicon', 'Enables the favicon checker (default: `false`).'
   p.option 'check_html', '--check-html', 'Enables HTML validation errors from Nokogiri (default: `false`).'
   p.option 'directory_index_file', '--directory-index-file', String, 'Sets the file to look for when a link refers to a directory. (default: `index.html`)'
-  p.option 'disable_external', '--disable-external', 'Disables the external link checker (default: `false`)'
-  p.option 'error_sort', '--error-sort SORT', 'Defines the sort order for error output. Can be `path`, `desc`, or `status` (default: `path`).'
+  p.option 'disable_external', '--disable-external', 'If `true`, does not run the external link checker, which can take a lot of time (default: `false`)'
+  p.option 'empty_alt_ignore', '--empty-alt-ignore', 'If `true`, ignores images with empty alt tags'
+  p.option 'error_sort', '--error-sort SORT', 'Defines the sort order for error output. Can be `:path`, `:desc`, or `:status` (default: `path`).'
   p.option 'enforce_https', '--enforce-https', 'Fails a link if it\'s not marked as `https` (default: `false`).'
-  p.option 'ext', '--ext EXT', String, 'The extension of your HTML files (default: `.html`)'
-  p.option 'file_ignore', '--file-ignore file1,[file2,...]', Array, 'Comma-separated list of Strings or RegExps containing file paths that are safe to ignore'
-  p.option 'href_ignore', '--href-ignore link1,[link2,...]', Array, 'Comma-separated list of Strings or RegExps containing `href`s that are safe to ignore.'
-  p.option 'href_swap', '--href-swap re:string,[re:string,...]', Array, 'Comma-separated list of key-value pairs of `RegExp:String`. Transforms links matching `RegExp` into `String`'
+  p.option 'ext', '--ext EXT', String, 'The extension of your HTML files including the dot. (default: `.html`)'
+  p.option 'file_ignore', '--file-ignore file1,[file2,...]', Array, 'A comma-separated list of Strings or RegExps containing file paths that are safe to ignore'
+  p.option 'href_ignore', '--href-ignore link1,[link2,...]', Array, 'A comma-separated list of Strings or RegExps containing `href`s that are safe to ignore. Note that non-HTTP(S) URIs are always ignored. **Will be renamed in a future release.**'
+  p.option 'href_swap', '--href-swap re:string,[re:string,...]', Array, 'A comma-separated list containing key-value pairs of `RegExp => String`. It transforms links that match `RegExp` into `String` via `gsub`. **Will be renamed in a future release.**'
   p.option 'ignore_script_embeds', '--ignore-script-embeds', 'Ignore `check_html` errors associated with `script`s (default: `false`)'
-  p.option 'only_4xx', '--only-4xx', 'Only reports errors for links that fall within the 4x status code range.'
-  p.option 'url_ignore', '--url-ignore link1,[link2,...]', Array, 'Comma-separated list of Strings or RegExps containing URLs that are safe to ignore.'
-  p.option 'verbose', '--verbose', 'Enables more verbose logging.'
+  p.option 'only_4xx', '--only-4xx', 'Only reports errors for links that fall within the 4xx status code range'
+  p.option 'url_ignore', '--url-ignore link1,[link2,...]', Array, 'A comma-separated list of Strings or RegExps containing URLs that are safe to ignore. It affects all HTML attributes. Note that non-HTTP(S) URIs are always ignored'
+  p.option 'verbose', '--verbose', 'If `true`, outputs extra information as the checking happens. Useful for debugging. **Will be deprecated in a future release.**'
   p.option 'verbosity', '--verbosity', String, 'Sets the logging level, as determined by Yell'
 
   p.action do |args, opts|

--- a/bin/htmlproof
+++ b/bin/htmlproof
@@ -6,14 +6,6 @@ $LOAD_PATH.unshift File.join(File.dirname(__FILE__), *%w( .. lib ))
 require 'html/proofer'
 require 'mercenary'
 
-def to_regex?(item)
-  if item.start_with?('/') && item.end_with?('/')
-    Regexp.new item[1...-1]
-  else
-    item
-  end
-end
-
 Mercenary.program(:htmlproof) do |p|
   p.version HTML::Proofer::VERSION
   p.description %(Test your rendered HTML files to make sure they're accurate.)
@@ -52,7 +44,7 @@ Mercenary.program(:htmlproof) do |p|
     # prepare everything to go to proofer
     p.options.select { |o| !opts[o.config_key].nil? }.each do |option|
       if option.return_type.to_s == 'Array' # TODO: is_a? doesn't work here?
-        opts[option.config_key] = opts[option.config_key].map { |i| to_regex?(i) }
+        opts[option.config_key] = opts[option.config_key].map { |i| HTML::Proofer::Configuration.to_regex?(i) }
       end
       options[option.config_key.to_sym] = opts[option.config_key]
     end
@@ -68,7 +60,7 @@ Mercenary.program(:htmlproof) do |p|
 
     # check for ignore_scripts_embeds as it should be set in :validation
     unless opts['ignore_script_embeds'].nil?
-        options[:validation] = { :ignore_script_embeds => true }
+      options[:validation] = { :ignore_script_embeds => true }
     end
 
     options[:error_sort] = opts['error-sort'].to_sym unless opts['error-sort'].nil?

--- a/lib/html/proofer.rb
+++ b/lib/html/proofer.rb
@@ -22,17 +22,6 @@ module HTML
 
     attr_reader :options, :typhoeus_opts, :hydra_opts, :parallel_opts, :validation_opts, :external_urls, :iterable_external_urls
 
-    TYPHOEUS_DEFAULTS = {
-      :followlocation => true,
-      :headers => {
-        'User-Agent' => "Mozilla/5.0 (compatible; HTML Proofer/#{VERSION}; +https://github.com/gjtorikian/html-proofer)"
-      }
-    }
-
-    HYDRA_DEFAULTS = {
-      :max_concurrency => 50
-    }
-
     def initialize(src, opts = {})
       FileUtils.mkdir_p(STORAGE_DIR) unless File.exist?(STORAGE_DIR)
 
@@ -45,31 +34,12 @@ module HTML
         warn '`@options[:href_ignore]` will be renamed in a future 3.x.x release: http://git.io/vGHHy'
       end
 
-      @proofer_opts = {
-        :ext => '.html',
-        :check_favicon => false,
-        :href_swap => [],
-        :href_ignore => [],
-        :allow_hash_href => false,
-        :file_ignore => [],
-        :url_ignore => [],
-        :check_external_hash => false,
-        :alt_ignore => [],
-        :empty_alt_ignore => false,
-        :enforce_https => false,
-        :disable_external => false,
-        :verbose => false,
-        :only_4xx => false,
-        :directory_index_file => 'index.html',
-        :check_html => false,
-        :error_sort => :path,
-        :checks_to_ignore => []
-      }
+      @proofer_opts = HTML::Proofer::Configuration::PROOFER_DEFAULTS
 
-      @typhoeus_opts = TYPHOEUS_DEFAULTS.merge(opts[:typhoeus] || {})
+      @typhoeus_opts = HTML::Proofer::Configuration::TYPHOEUS_DEFAULTS.merge(opts[:typhoeus] || {})
       opts.delete(:typhoeus)
 
-      @hydra_opts = HYDRA_DEFAULTS.merge(opts[:hydra] || {})
+      @hydra_opts = HTML::Proofer::Configuration::HYDRA_DEFAULTS.merge(opts[:hydra] || {})
       opts.delete(:hydra)
 
       # fall back to parallel defaults

--- a/lib/html/proofer/configuration.rb
+++ b/lib/html/proofer/configuration.rb
@@ -1,6 +1,6 @@
 module HTML
   class Proofer
-    class Configuration < Hash
+    module Configuration
       require_relative 'version'
 
       PROOFER_DEFAULTS = {
@@ -34,6 +34,14 @@ module HTML
       HYDRA_DEFAULTS = {
         :max_concurrency => 50
       }
+
+      def self.to_regex?(item)
+        if item.start_with?('/') && item.end_with?('/')
+          Regexp.new item[1...-1]
+        else
+          item
+        end
+      end
     end
   end
 end

--- a/lib/html/proofer/configuration.rb
+++ b/lib/html/proofer/configuration.rb
@@ -1,6 +1,7 @@
 module HTML
   class Proofer
     class Configuration < Hash
+      require_relative 'version'
 
       PROOFER_DEFAULTS = {
         :ext => '.html',
@@ -26,14 +27,13 @@ module HTML
       TYPHOEUS_DEFAULTS = {
         :followlocation => true,
         :headers => {
-          'User-Agent' => "Mozilla/5.0 (compatible; HTML Proofer/#{VERSION}; +https://github.com/gjtorikian/html-proofer)"
+          'User-Agent' => "Mozilla/5.0 (compatible; HTML Proofer/#{HTML::Proofer::VERSION}; +https://github.com/gjtorikian/html-proofer)"
         }
       }
 
       HYDRA_DEFAULTS = {
         :max_concurrency => 50
       }
-
     end
   end
 end

--- a/lib/html/proofer/configuration.rb
+++ b/lib/html/proofer/configuration.rb
@@ -1,0 +1,39 @@
+module HTML
+  class Proofer
+    class Configuration < Hash
+
+      PROOFER_DEFAULTS = {
+        :ext => '.html',
+        :check_favicon => false,
+        :href_swap => [],
+        :href_ignore => [],
+        :allow_hash_href => false,
+        :file_ignore => [],
+        :url_ignore => [],
+        :check_external_hash => false,
+        :alt_ignore => [],
+        :empty_alt_ignore => false,
+        :enforce_https => false,
+        :disable_external => false,
+        :verbose => false,
+        :only_4xx => false,
+        :directory_index_file => 'index.html',
+        :check_html => false,
+        :error_sort => :path,
+        :checks_to_ignore => []
+      }
+
+      TYPHOEUS_DEFAULTS = {
+        :followlocation => true,
+        :headers => {
+          'User-Agent' => "Mozilla/5.0 (compatible; HTML Proofer/#{VERSION}; +https://github.com/gjtorikian/html-proofer)"
+        }
+      }
+
+      HYDRA_DEFAULTS = {
+        :max_concurrency => 50
+      }
+
+    end
+  end
+end

--- a/spec/html/proofer/command_spec.rb
+++ b/spec/html/proofer/command_spec.rb
@@ -91,4 +91,24 @@ describe 'Command test' do
     output = make_bin('--allow-hash-href', broken)
     expect(output).to match('successfully')
   end
+
+  it 'has every option' do
+    config_keys = HTML::Proofer::Configuration::PROOFER_DEFAULTS.keys
+    bin_file = File.read('bin/htmlproof')
+    help_output = make_bin('--help')
+    readme = File.read('README.md')
+    config_keys.map(&:to_s).each do |key|
+      # match options
+      expect(bin_file).to match(key)
+      readme.each_line do |line|
+        next unless line.match(/\| `#{key}`/)
+        description = line.split('|')[2].strip
+        description.gsub!('A hash', 'A comma-separated list')
+        description.gsub!('An array', 'A comma-separated list')
+        description.sub!(/\.$/, '')
+        # match README description for option
+        expect(help_output).to include(description)
+      end
+    end
+  end
 end


### PR DESCRIPTION
For too long, too many config options have been either poorly documented or completely missing from the `htmlproof` executable. 

This PR adds a test to ensure that the docs and options are in sync. 