### PR TITLE
Fix attempts at cleaning content

### DIFF
--- a/lib/html/proofer/checks/html.rb
+++ b/lib/html/proofer/checks/html.rb
@@ -39,6 +39,7 @@ class HtmlCheck < ::HTML::Proofer::CheckRunner
 
       # tags embedded in scripts are used in templating languages: http://git.io/vOovv
       next if @validation_opts[:ignore_script_embeds] && message =~ SCRIPT_EMBEDS_MSG
+      next if message =~ /htmlParseEntityRef: expecting ';'/
 
       add_issue(message, line)
     end

--- a/lib/html/proofer/checks/html.rb
+++ b/lib/html/proofer/checks/html.rb
@@ -39,7 +39,6 @@ class HtmlCheck < ::HTML::Proofer::CheckRunner
 
       # tags embedded in scripts are used in templating languages: http://git.io/vOovv
       next if @validation_opts[:ignore_script_embeds] && message =~ SCRIPT_EMBEDS_MSG
-      next if message =~ /htmlParseEntityRef: expecting ';'/
 
       add_issue(message, line)
     end

--- a/lib/html/proofer/utils.rb
+++ b/lib/html/proofer/utils.rb
@@ -36,7 +36,6 @@ module HTML
 
         matches.flatten.each do |url|
           escaped_url = url.gsub(/&(?!amp;)/, '&amp;')
-          escaped_url = escaped_url.gsub(%r{/}, '&#47;')
           string.gsub!(url, escaped_url)
         end
         string

--- a/lib/html/proofer/utils.rb
+++ b/lib/html/proofer/utils.rb
@@ -16,7 +16,7 @@ module HTML
           content = path
         end
 
-        Nokogiri::HTML(content)
+        Nokogiri::HTML(clean_content(content))
       end
       module_function :create_nokogiri
 
@@ -31,18 +31,17 @@ module HTML
       # address a problem with Nokogiri's parsing URL entities
       # problem from http://git.io/vBYU1
       # solution from http://git.io/vBYUi
-      # UPDATE: Not worth my time to figure out why this is happening.
-      # def clean_content(string)
-      #   matches = string.scan(%r{https?://([^>]+)}i)
-      #
-      #   matches.flatten.each do |url|
-      #     escaped_url = url.gsub(/&(?!amp;)/, '&amp;')
-      #     escaped_url = escaped_url.gsub(%r{/}, '&#47;')
-      #     string.gsub!(url, escaped_url)
-      #   end
-      #   string
-      # end
-      # module_function :clean_content
+      def clean_content(string)
+        matches = string.scan(%r{https?://([^>]+)}i)
+
+        matches.flatten.each do |url|
+          escaped_url = url.gsub(/&(?!amp;)/, '&amp;')
+          escaped_url = escaped_url.gsub(%r{/}, '&#47;')
+          string.gsub!(url, escaped_url)
+        end
+        string
+      end
+      module_function :clean_content
     end
   end
 end

--- a/lib/html/proofer/utils.rb
+++ b/lib/html/proofer/utils.rb
@@ -16,7 +16,7 @@ module HTML
           content = path
         end
 
-        Nokogiri::HTML(clean_content(content))
+        Nokogiri::HTML(content)
       end
       module_function :create_nokogiri
 
@@ -31,17 +31,18 @@ module HTML
       # address a problem with Nokogiri's parsing URL entities
       # problem from http://git.io/vBYU1
       # solution from http://git.io/vBYUi
-      def clean_content(string)
-        matches = string.scan(%r{https?://([^>]+)}i)
-
-        matches.flatten.each do |url|
-          escaped_url = url.gsub(/&(?!amp;)/, '&amp;')
-          escaped_url = escaped_url.gsub(%r{/}, '&#47;')
-          string.gsub!(url, escaped_url)
-        end
-        string
-      end
-      module_function :clean_content
+      # UPDATE: Not worth my time to figure out why this is happening.
+      # def clean_content(string)
+      #   matches = string.scan(%r{https?://([^>]+)}i)
+      #
+      #   matches.flatten.each do |url|
+      #     escaped_url = url.gsub(/&(?!amp;)/, '&amp;')
+      #     escaped_url = escaped_url.gsub(%r{/}, '&#47;')
+      #     string.gsub!(url, escaped_url)
+      #   end
+      #   string
+      # end
+      # module_function :clean_content
     end
   end
 end

--- a/spec/html/proofer/fixtures/html/normal_looking_page.html
+++ b/spec/html/proofer/fixtures/html/normal_looking_page.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,300,700' rel='stylesheet' type='text/css'>
+  <script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-3769691-28', 'auto');
+  ga('send', 'pageview');
+</script>
+
+  <!-- Begin Jekyll SEO tag -->
+<title>Not found - GitHub and Government</title>
+<meta property="og:title" content="Not found - GitHub and Government" />
+<meta name="description" content="GitHub helps government build software better, together" />
+<meta property='og:description' content="GitHub helps government build software better, together" />
+<link rel="canonical" href="http://government.github.com/404.html" itemprop="url" />
+<meta property='og:url' content='http://government.github.com/404.html' />
+<meta property="og:site_name" content="GitHub and Government" />
+<script type="application/ld+json">
+{
+"@context" : "http://schema.org",
+"@type" : "WebSite",
+"name" : "GitHub and Government",
+"url" : "http://government.github.com"
+}
+</script>
+<!-- End Jekyll SEO tag -->
+
+</head>
+
+<body class="support-page">
+
+  <div class="full-width olives">
+    <div class="navbar">
+        <div class="container">
+            <ul>
+              <li><a href="https://github.com/government/welcome#readme">Peer Group</a></li>
+            </ul>
+        </div>
+    </div>
+    <!-- .full-width here gets closed on support-page.html and home.html layouts -->
+
+</div>
+  <div id="Not-found" class="container support-page">
+
+    <div class="mini-section">
+        <h1>Not found</h1>
+        <h3 class="description lead-graf"></h3>
+    </div>
+  </div>
+
+  <div class="container mini-section">
+        <h2 id="the-page-youre-looking-for-doesnt-seem-to-be-there">The page you’re looking for doesn’t seem to be there!</h2>
+
+<h3 id="maybe-we-can-find-it-together-if-you-search-below">Maybe we can find it together if you search below.</h3>
+
+<script>
+  var GOOG_FIXURL_LANG = "en";
+  var GOOG_FIXURL_SITE = "http://government.github.com";
+</script>
+
+<script src="//linkhelp.clients.google.com/tbproxy/lh/wm/fixurl.js"></script>
+
+
+  </div>
+
+<script>
+  $(document).ready(function () {
+    (function ($) {
+      $('#filter').keyup(function () {
+        var rex = new RegExp($(this).val(), 'i');
+        $('.searchable tr').hide();
+        $('.searchable tr').filter(function () {
+            return rex.test($(this).text());
+        }).show();
+
+        if ($('.govtable tr:visible').length === 0) {
+          $('.govtable.no-matches').show();
+        } else {
+          $('.govtable.no-matches').hide();
+          $('.govtable.table-header').show();
+        };
+
+        if ($('.civictable tr:visible').length === 0) {
+          $('.civictable.no-matches').show();
+        } else {
+          $('.civictable.no-matches').hide();
+          $('.civictable.table-header').show();
+        };
+      })
+    }(jQuery));
+  });
+</script>
+
+    <footer class="container">
+      <div class="site-footer clearfix">
+        <ul class="site-footer-links right no-style-list">
+          <li class="no-mobile"><a href="https://help.github.com/articles/github-glossary" target="_blank">Glossary</a></li>
+          <li class="no-mobile"><a href="https://help.github.com/security">Security</a></li>
+          <li><a href="mailto:government@github.com">Contact Us</a></li>
+        </ul>
+
+        <ul class="site-footer-links no-style-list">
+          <li class="no-mobile">&copy; 2014 GitHub Inc. All rights reserved.</li>
+          <li><a href="https://github.com/">GitHub.com</a></li>
+          <li class="no-mobile"><a href="https://github.com/about">About</a></li>
+          <li class="no-mobile"><a href="https://github.com/features/">Features</a></li>
+        </ul>
+      </div>
+    </footer>
+
+  <script>anchors.add('.org-table h4');</script>
+  </body>
+</html>
+<!-- Proudly powered by GitHub Pages ~ Generated 2015-12-09 14:05:31 -0800 -->

--- a/spec/html/proofer/fixtures/vcr_cassettes/html/normal_looking_page_html_check_html_true_.yml
+++ b/spec/html/proofer/fixtures/vcr_cassettes/html/normal_looking_page_html_check_html_true_.yml
@@ -1,0 +1,550 @@
+---
+http_interactions:
+- request:
+    method: head
+    uri: https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,300,700
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/2.6.0; +https://github.com/gjtorikian/html-proofer)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/css
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      Expires:
+      - Wed, 09 Dec 2015 22:07:37 GMT
+      Date:
+      - Wed, 09 Dec 2015 22:07:37 GMT
+      Cache-Control:
+      - private, max-age=86400
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alternate-Protocol:
+      - 443:quic,p=0
+      Alt-Svc:
+      - clear
+      Transfer-Encoding:
+      - chunked
+      Accept-Ranges:
+      - none
+      Vary:
+      - Accept-Encoding
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,300,700
+  recorded_at: Wed, 09 Dec 2015 22:07:37 GMT
+- request:
+    method: head
+    uri: https://github.com/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/2.6.0; +https://github.com/gjtorikian/html-proofer)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Wed, 09 Dec 2015 22:07:37 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Status:
+      - 200 OK
+      Content-Security-Policy:
+      - 'default-src *; script-src assets-cdn.github.com; object-src assets-cdn.github.com;
+        style-src ''self'' ''unsafe-inline'' ''unsafe-eval'' assets-cdn.github.com;
+        img-src ''self'' data: assets-cdn.github.com identicons.github.com www.google-analytics.com
+        checkout.paypal.com collector.githubapp.com *.githubusercontent.com *.gravatar.com
+        *.wp.com; media-src ''none''; frame-src ''self'' render.githubusercontent.com
+        gist.github.com www.youtube.com player.vimeo.com checkout.paypal.com; font-src
+        assets-cdn.github.com; connect-src ''self'' live.github.com wss://live.github.com
+        uploads.github.com status.github.com api.github.com www.google-analytics.com
+        api.braintreegateway.com client-analytics.braintreegateway.com github-cloud.s3.amazonaws.com;
+        base-uri ''self''; form-action ''self'' github.com gist.github.com'
+      Public-Key-Pins:
+      - max-age=300; pin-sha256="WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18="; pin-sha256="JbQbUG5JMJUoI6brnx0x3vZF6jilxsapbXGVfjhN8Fg=";
+        includeSubDomains
+      Cache-Control:
+      - no-cache
+      Vary:
+      - X-PJAX
+      - Accept-Encoding
+      X-UA-Compatible:
+      - IE=Edge,chrome=1
+      Set-Cookie:
+      - logged_in=no; domain=.github.com; path=/; expires=Sun, 09 Dec 2035 22:07:37
+        -0000; secure; HttpOnly
+      - _gh_sess=eyJzZXNzaW9uX2lkIjoiZGQ1Mzk2MmE0MjVjN2EyNGMyOTlmNTAwMWIyMjZlMjMiLCJfY3NyZl90b2tlbiI6ImJlZmVGN0tBZVJwc2x3NmdvQnBJR1FqNWNzWEIxK2hSTEFsWFdrbnAzY289In0%3D--92ebcb3de6b98f1f2b6a9238d944de4c0a8f39ef;
+        path=/; secure; HttpOnly
+      X-Request-Id:
+      - d18f4ac59b4aa4933704fe86398dfe33
+      X-Runtime:
+      - '0.009182'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - deny
+      X-Served-By:
+      - cbc5fb89a0e5c9db5298b4b976ca7aca
+      X-GitHub-Request-Id:
+      - 04358526:448D:371F329:5668A629
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://github.com/
+  recorded_at: Wed, 09 Dec 2015 22:07:37 GMT
+- request:
+    method: head
+    uri: https://github.com/features/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/2.6.0; +https://github.com/gjtorikian/html-proofer)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Wed, 09 Dec 2015 22:07:37 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Status:
+      - 200 OK
+      Content-Security-Policy:
+      - 'default-src *; script-src assets-cdn.github.com; object-src assets-cdn.github.com;
+        style-src ''self'' ''unsafe-inline'' ''unsafe-eval'' assets-cdn.github.com;
+        img-src ''self'' data: assets-cdn.github.com identicons.github.com www.google-analytics.com
+        checkout.paypal.com collector.githubapp.com *.githubusercontent.com *.gravatar.com
+        *.wp.com; media-src ''none''; frame-src ''self'' render.githubusercontent.com
+        gist.github.com www.youtube.com player.vimeo.com checkout.paypal.com; font-src
+        assets-cdn.github.com; connect-src ''self'' live.github.com wss://live.github.com
+        uploads.github.com status.github.com api.github.com www.google-analytics.com
+        api.braintreegateway.com client-analytics.braintreegateway.com github-cloud.s3.amazonaws.com;
+        base-uri ''self''; form-action ''self'' github.com gist.github.com'
+      Public-Key-Pins:
+      - max-age=300; pin-sha256="WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18="; pin-sha256="JbQbUG5JMJUoI6brnx0x3vZF6jilxsapbXGVfjhN8Fg=";
+        includeSubDomains
+      Cache-Control:
+      - no-cache
+      Vary:
+      - X-PJAX
+      - Accept-Encoding
+      X-UA-Compatible:
+      - IE=Edge,chrome=1
+      Set-Cookie:
+      - logged_in=no; domain=.github.com; path=/; expires=Sun, 09 Dec 2035 22:07:37
+        -0000; secure; HttpOnly
+      - _gh_sess=eyJzZXNzaW9uX2lkIjoiMWU5ODQ4Y2FhN2RhZGRmNWU0YzY0MDEzMDU2MzE5YmYiLCJfY3NyZl90b2tlbiI6Imk1V3VCNWxsS05zT2NmRUZuSEtBVk1kY3REcWFLK21QVmtCTzRvTmR5d289In0%3D--0d8304c283d9d993b2101c8594be83ef43d935aa;
+        path=/; secure; HttpOnly
+      X-Request-Id:
+      - 416673bd4477aedeef8a657f087747b7
+      X-Runtime:
+      - '0.016425'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - deny
+      X-Served-By:
+      - cbc5fb89a0e5c9db5298b4b976ca7aca
+      X-GitHub-Request-Id:
+      - 04358526:448A:41C8E42:5668A629
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://github.com/features/
+  recorded_at: Wed, 09 Dec 2015 22:07:37 GMT
+- request:
+    method: head
+    uri: https://github.com/about
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/2.6.0; +https://github.com/gjtorikian/html-proofer)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Wed, 09 Dec 2015 22:07:37 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Status:
+      - 200 OK
+      Content-Security-Policy:
+      - 'default-src *; script-src assets-cdn.github.com; object-src assets-cdn.github.com;
+        style-src ''self'' ''unsafe-inline'' ''unsafe-eval'' assets-cdn.github.com;
+        img-src ''self'' data: assets-cdn.github.com identicons.github.com www.google-analytics.com
+        checkout.paypal.com collector.githubapp.com *.githubusercontent.com *.gravatar.com
+        *.wp.com; media-src ''none''; frame-src ''self'' render.githubusercontent.com
+        gist.github.com www.youtube.com player.vimeo.com checkout.paypal.com; font-src
+        assets-cdn.github.com; connect-src ''self'' live.github.com wss://live.github.com
+        uploads.github.com status.github.com api.github.com www.google-analytics.com
+        api.braintreegateway.com client-analytics.braintreegateway.com github-cloud.s3.amazonaws.com;
+        base-uri ''self''; form-action ''self'' github.com gist.github.com'
+      Public-Key-Pins:
+      - max-age=300; pin-sha256="WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18="; pin-sha256="JbQbUG5JMJUoI6brnx0x3vZF6jilxsapbXGVfjhN8Fg=";
+        includeSubDomains
+      Cache-Control:
+      - no-cache
+      Vary:
+      - X-PJAX
+      - Accept-Encoding
+      X-UA-Compatible:
+      - IE=Edge,chrome=1
+      Set-Cookie:
+      - logged_in=no; domain=.github.com; path=/; expires=Sun, 09 Dec 2035 22:07:37
+        -0000; secure; HttpOnly
+      - _gh_sess=eyJzZXNzaW9uX2lkIjoiMDhhN2M0YzczYjllN2Y5MTNiNjkwZGZiMjU1NGQ0ZDkiLCJfY3NyZl90b2tlbiI6IndpaDhnQ2NWR1FLRUpRRFQxeDMzVko5aTdHYVpBdkRMMHdtSWdhT1V6SVE9In0%3D--9d2eabcef073400dcd80221e3a81c1bc4cf56ecf;
+        path=/; secure; HttpOnly
+      X-Request-Id:
+      - dd701c258495bd7be5d334d63132af3c
+      X-Runtime:
+      - '0.058611'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - deny
+      X-Served-By:
+      - 3f38dada85f97412f7f824e59f77fa9d
+      X-GitHub-Request-Id:
+      - 04358526:4489:398727F:5668A629
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://github.com/about
+  recorded_at: Wed, 09 Dec 2015 22:07:37 GMT
+- request:
+    method: head
+    uri: http://government.github.com/404.html
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/2.6.0; +https://github.com/gjtorikian/html-proofer)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Content-Type:
+      - text/html; charset=utf-8
+      Last-Modified:
+      - Wed, 09 Dec 2015 17:39:14 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Expires:
+      - Wed, 09 Dec 2015 22:17:37 GMT
+      Cache-Control:
+      - max-age=600
+      X-GitHub-Request-Id:
+      - C71B4F1A:448F:3EB3DD6:5668A629
+      Content-Length:
+      - '4948'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Wed, 09 Dec 2015 22:07:38 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-lax1426-LAX
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      X-Fastly-Request-ID:
+      - dfcf768e4c17def3ec7809b68d22c68171efe6b7
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://government.github.com/404.html
+  recorded_at: Wed, 09 Dec 2015 22:07:38 GMT
+- request:
+    method: head
+    uri: https://help.github.com/security
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/2.6.0; +https://github.com/gjtorikian/html-proofer)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Content-Type:
+      - text/html; charset=utf-8
+      Last-Modified:
+      - Wed, 09 Dec 2015 00:26:28 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Expires:
+      - Wed, 09 Dec 2015 22:17:38 GMT
+      Cache-Control:
+      - max-age=600
+      X-GitHub-Request-Id:
+      - C71B4F1F:448F:3EB3DEF:5668A629
+      Content-Length:
+      - '376'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Wed, 09 Dec 2015 22:07:38 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-lax1431-LAX
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      X-Fastly-Request-ID:
+      - a1d5b746cc626d5829cd49e4df347263d8655568
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://help.github.com/security/
+  recorded_at: Wed, 09 Dec 2015 22:07:38 GMT
+- request:
+    method: head
+    uri: https://help.github.com/articles/github-glossary
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/2.6.0; +https://github.com/gjtorikian/html-proofer)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Content-Type:
+      - text/html; charset=utf-8
+      Last-Modified:
+      - Wed, 09 Dec 2015 00:26:27 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Expires:
+      - Wed, 09 Dec 2015 22:17:38 GMT
+      Cache-Control:
+      - max-age=600
+      X-GitHub-Request-Id:
+      - C71B4F17:448F:3EB3DEB:5668A629
+      Content-Length:
+      - '17330'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Wed, 09 Dec 2015 22:07:38 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-lax1423-LAX
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      X-Fastly-Request-ID:
+      - 7ca5bc98296620aa106f90cc3d19eabfd8ddb10e
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://help.github.com/articles/github-glossary/
+  recorded_at: Wed, 09 Dec 2015 22:07:38 GMT
+- request:
+    method: head
+    uri: http://linkhelp.clients.google.com/tbproxy/lh/wm/fixurl.js
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/2.6.0; +https://github.com/gjtorikian/html-proofer)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/javascript; charset=UTF-8
+      Date:
+      - Wed, 09 Dec 2015 22:08:45 GMT
+      Expires:
+      - Wed, 09 Dec 2015 22:08:45 GMT
+      Cache-Control:
+      - public, max-age=0
+      Server:
+      - HTTP server (unknown)
+      X-XSS-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      Transfer-Encoding:
+      - chunked
+      Accept-Ranges:
+      - none
+      Vary:
+      - Accept-Encoding
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: http://linkhelp.clients.google.com/tbproxy/lh/wm/fixurl.js
+  recorded_at: Wed, 09 Dec 2015 22:08:45 GMT
+- request:
+    method: head
+    uri: https://github.com/government/welcome#readme
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/2.6.0; +https://github.com/gjtorikian/html-proofer)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Wed, 09 Dec 2015 22:08:45 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Status:
+      - 200 OK
+      Content-Security-Policy:
+      - 'default-src *; script-src assets-cdn.github.com; object-src assets-cdn.github.com;
+        style-src ''self'' ''unsafe-inline'' ''unsafe-eval'' assets-cdn.github.com;
+        img-src ''self'' data: assets-cdn.github.com identicons.github.com www.google-analytics.com
+        checkout.paypal.com collector.githubapp.com *.githubusercontent.com *.gravatar.com
+        *.wp.com; media-src ''none''; frame-src ''self'' render.githubusercontent.com
+        gist.github.com www.youtube.com player.vimeo.com checkout.paypal.com; font-src
+        assets-cdn.github.com; connect-src ''self'' live.github.com wss://live.github.com
+        uploads.github.com status.github.com api.github.com www.google-analytics.com
+        api.braintreegateway.com client-analytics.braintreegateway.com github-cloud.s3.amazonaws.com;
+        base-uri ''self''; form-action ''self'' github.com gist.github.com'
+      Public-Key-Pins:
+      - max-age=300; pin-sha256="WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18="; pin-sha256="JbQbUG5JMJUoI6brnx0x3vZF6jilxsapbXGVfjhN8Fg=";
+        includeSubDomains
+      Cache-Control:
+      - no-cache
+      Vary:
+      - X-PJAX
+      - Accept-Encoding
+      X-UA-Compatible:
+      - IE=Edge,chrome=1
+      Set-Cookie:
+      - logged_in=no; domain=.github.com; path=/; expires=Sun, 09 Dec 2035 22:08:45
+        -0000; secure; HttpOnly
+      - _gh_sess=eyJzZXNzaW9uX2lkIjoiN2Y1ZTExODBmNjgyYzk4NTllMTA1ZDYwZTE2MTU1NWEiLCJzcHlfcmVwbyI6ImdvdmVybm1lbnQvd2VsY29tZSIsInNweV9yZXBvX2F0IjoxNDQ5Njk4OTI1LCJfY3NyZl90b2tlbiI6InNNd1doa3hLSENZb2tMZ2dFbHNhZ21MeCtyY2dzM3JxS0E0QW9sUzFLV0U9IiwiZmxhc2giOnsiZGlzY2FyZCI6WyJhbmFseXRpY3NfbG9jYXRpb24iXSwiZmxhc2hlcyI6eyJhbmFseXRpY3NfbG9jYXRpb24iOiIvPHVzZXItbmFtZT4vPHJlcG8tbmFtZT4ifX19--6ac864efc5f061cb648492d5e37eda8bff3ff85b;
+        path=/; secure; HttpOnly
+      X-Request-Id:
+      - 748014257528ac8edfc28a7dfc0fb989
+      X-Runtime:
+      - '0.064337'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - deny
+      X-Served-By:
+      - 50b06cef3698e972f044d7dc2cb41530
+      X-GitHub-Request-Id:
+      - 04358526:6925:47A02E0:5668A66D
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://github.com/government/welcome
+  recorded_at: Wed, 09 Dec 2015 22:08:45 GMT
+recorded_with: VCR 2.9.3

--- a/spec/html/proofer/html_spec.rb
+++ b/spec/html/proofer/html_spec.rb
@@ -75,4 +75,11 @@ describe 'Html test' do
     proofer = run_proofer(weird_onclick, opts)
     expect(proofer.failed_tests).to eq []
   end
+
+  it 'validates normal looking government HTML' do
+    opts = { :check_html => true }
+    normal_looking_page = "#{FIXTURES_DIR}/html/normal_looking_page.html"
+    proofer = run_proofer(normal_looking_page, opts)
+    expect(proofer.failed_tests).to eq []
+  end
 end


### PR DESCRIPTION
It seems that Nokogiri is overly strict and any attempt to change its strictness is not really working out.

This PR quasi reverts changes in https://github.com/gjtorikian/html-proofer/pull/273, in that it simply ignores the error instead of rewriting content.

Related to https://github.com/github/government.github.com/pull/423.