### PR TITLE
Drop href ignore/swap in favor of url ignore/swap

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ You'll get a new program called `htmlproof` with this gem. Terrific!
 Use it like you'd expect to:
 
 ``` bash
-htmlproof ./out --href-swap wow:cow,mow:doh --ext .html.erb --href-ignore www.github.com
+htmlproof ./out --href-swap wow:cow,mow:doh --ext .html.erb --url-ignore www.github.com
 ```
 
 Note: since `href_swap` is a bit special, you'll pass in a pair of `RegEx:String` values.
@@ -168,7 +168,6 @@ The `HTML::Proofer` constructor takes an optional hash of additional options:
 | `ext` | The extension of your HTML files including the dot. | `.html`
 | `external_only` | Only checks problems with external references. | `false`
 | `file_ignore` | An array of Strings or RegExps containing file paths that are safe to ignore. | `[]` |
-| `href_ignore` | An array of Strings or RegExps containing `href`s that are safe to ignore. Note that non-HTTP(S) URIs are always ignored. **Will be renamed in a future release.** | `[]` |
 | `href_swap` | A hash containing key-value pairs of `RegExp => String`. It transforms links that match `RegExp` into `String` via `gsub`. **Will be renamed in a future release.** | `{}` |
 | `only_4xx` | Only reports errors for links that fall within the 4xx status code range. | `false` |
 | `url_ignore` | An array of Strings or RegExps containing URLs that are safe to ignore. It affects all HTML attributes. Note that non-HTTP(S) URIs are always ignored. | `[]` |

--- a/README.md
+++ b/README.md
@@ -99,10 +99,10 @@ You'll get a new program called `htmlproof` with this gem. Terrific!
 Use it like you'd expect to:
 
 ``` bash
-htmlproof ./out --href-swap wow:cow,mow:doh --ext .html.erb --url-ignore www.github.com
+htmlproof ./out --url-swap wow:cow,mow:doh --ext .html.erb --url-ignore www.github.com
 ```
 
-Note: since `href_swap` is a bit special, you'll pass in a pair of `RegEx:String` values.
+Note: since `url_swap` is a bit special, you'll pass in a pair of `RegEx:String` values.
 `htmlproof` will figure out what you mean.
 
 ### Using with Jekyll
@@ -168,9 +168,9 @@ The `HTML::Proofer` constructor takes an optional hash of additional options:
 | `ext` | The extension of your HTML files including the dot. | `.html`
 | `external_only` | Only checks problems with external references. | `false`
 | `file_ignore` | An array of Strings or RegExps containing file paths that are safe to ignore. | `[]` |
-| `href_swap` | A hash containing key-value pairs of `RegExp => String`. It transforms links that match `RegExp` into `String` via `gsub`. **Will be renamed in a future release.** | `{}` |
 | `only_4xx` | Only reports errors for links that fall within the 4xx status code range. | `false` |
 | `url_ignore` | An array of Strings or RegExps containing URLs that are safe to ignore. It affects all HTML attributes. Note that non-HTTP(S) URIs are always ignored. | `[]` |
+| `url_swap` | A hash containing key-value pairs of `RegExp => String`. It transforms URLs that match `RegExp` into `String` via `gsub`. | `{}` |
 | `verbose` | If `true`, outputs extra information as the checking happens. Useful for debugging. **Will be deprecated in a future release.**| `false` |
 | `verbosity` | Sets the logging level, as determined by [Yell](https://github.com/rudionrails/yell). | `:info`
 

--- a/bin/htmlproof
+++ b/bin/htmlproof
@@ -28,10 +28,10 @@ Mercenary.program(:htmlproof) do |p|
   p.option 'ext', '--ext EXT', String, 'The extension of your HTML files including the dot. (default: `.html`)'
   p.option 'external_only', '--external_only', 'Only checks problems with external references'
   p.option 'file_ignore', '--file-ignore file1,[file2,...]', Array, 'A comma-separated list of Strings or RegExps containing file paths that are safe to ignore'
-  p.option 'href_swap', '--href-swap re:string,[re:string,...]', Array, 'A comma-separated list containing key-value pairs of `RegExp => String`. It transforms links that match `RegExp` into `String` via `gsub`. **Will be renamed in a future release.**'
   p.option 'ignore_script_embeds', '--ignore-script-embeds', 'Ignore `check_html` errors associated with `script`s (default: `false`)'
   p.option 'only_4xx', '--only-4xx', 'Only reports errors for links that fall within the 4xx status code range'
   p.option 'url_ignore', '--url-ignore link1,[link2,...]', Array, 'A comma-separated list of Strings or RegExps containing URLs that are safe to ignore. It affects all HTML attributes. Note that non-HTTP(S) URIs are always ignored'
+  p.option 'url_swap', '--url-swap re:string,[re:string,...]', Array, 'A comma-separated list containing key-value pairs of `RegExp => String`. It transforms URLs that match `RegExp` into `String` via `gsub`.'
   p.option 'verbose', '--verbose', 'If `true`, outputs extra information as the checking happens. Useful for debugging. **Will be deprecated in a future release.**'
   p.option 'verbosity', '--verbosity', String, 'Sets the logging level, as determined by Yell'
 
@@ -50,11 +50,11 @@ Mercenary.program(:htmlproof) do |p|
     end
 
     # some minor manipulation of a special option
-    unless opts['href_swap'].nil?
-      options[:href_swap] = {}
-      opts['href_swap'].each do |s|
+    unless opts['url_swap'].nil?
+      options[:url_swap] = {}
+      opts['url_swap'].each do |s|
         pair = s.split(':', 2)
-        options[:href_swap][Regexp.new(pair[0])] = pair[1]
+        options[:url_swap][Regexp.new(pair[0])] = pair[1]
       end
     end
 

--- a/bin/htmlproof
+++ b/bin/htmlproof
@@ -28,7 +28,6 @@ Mercenary.program(:htmlproof) do |p|
   p.option 'ext', '--ext EXT', String, 'The extension of your HTML files including the dot. (default: `.html`)'
   p.option 'external_only', '--external_only', 'Only checks problems with external references'
   p.option 'file_ignore', '--file-ignore file1,[file2,...]', Array, 'A comma-separated list of Strings or RegExps containing file paths that are safe to ignore'
-  p.option 'href_ignore', '--href-ignore link1,[link2,...]', Array, 'A comma-separated list of Strings or RegExps containing `href`s that are safe to ignore. Note that non-HTTP(S) URIs are always ignored. **Will be renamed in a future release.**'
   p.option 'href_swap', '--href-swap re:string,[re:string,...]', Array, 'A comma-separated list containing key-value pairs of `RegExp => String`. It transforms links that match `RegExp` into `String` via `gsub`. **Will be renamed in a future release.**'
   p.option 'ignore_script_embeds', '--ignore-script-embeds', 'Ignore `check_html` errors associated with `script`s (default: `false`)'
   p.option 'only_4xx', '--only-4xx', 'Only reports errors for links that fall within the 4xx status code range'

--- a/lib/html/proofer.rb
+++ b/lib/html/proofer.rb
@@ -30,9 +30,6 @@ module HTML
       if opts[:verbose]
         warn '`@options[:verbose]` will be removed in a future 3.x.x release: http://git.io/vGHHh'
       end
-      if opts[:href_ignore]
-        warn '`@options[:href_ignore]` will be renamed in a future 3.x.x release: http://git.io/vGHHy'
-      end
 
       @proofer_opts = HTML::Proofer::Configuration::PROOFER_DEFAULTS
 

--- a/lib/html/proofer.rb
+++ b/lib/html/proofer.rb
@@ -72,9 +72,9 @@ module HTML
     end
 
     def check_list_of_links
-      if @options[:href_swap]
+      if @options[:url_swap]
         @src = @src.map do |url|
-          swap(url, @options[:href_swap])
+          swap(url, @options[:url_swap])
         end
       end
       @external_urls = Hash[*@src.map { |s| [s, nil] }.flatten]

--- a/lib/html/proofer/check_runner.rb
+++ b/lib/html/proofer/check_runner.rb
@@ -6,7 +6,7 @@ module HTML
     class CheckRunner
 
       attr_reader :issues, :src, :path, :options, :typhoeus_opts, :hydra_opts, :parallel_opts, \
-                  :validation_opts, :external_urls, :href_ignores, :url_ignores, :alt_ignores, \
+                  :validation_opts, :external_urls, :url_ignores, :alt_ignores, \
                   :empty_alt_ignore, :allow_hash_href
 
       def initialize(src, path, html, options, typhoeus_opts, hydra_opts, parallel_opts, validation_opts)
@@ -19,7 +19,6 @@ module HTML
         @parallel_opts = parallel_opts
         @validation_opts = validation_opts
         @issues = []
-        @href_ignores = @options[:href_ignore]
         @url_ignores = @options[:url_ignore]
         @alt_ignores = @options[:alt_ignore]
         @empty_alt_ignore = @options[:empty_alt_ignore]

--- a/lib/html/proofer/checkable.rb
+++ b/lib/html/proofer/checkable.rb
@@ -20,8 +20,8 @@ module HTML
         @type = self.class.name
         @line = obj.line
 
-        if @href && @check.options[:href_swap]
-          @href = swap(@href, @check.options[:href_swap])
+        if @href && @check.options[:url_swap]
+          @href = swap(@href, @check.options[:url_swap])
         end
 
         # fix up missing protocols

--- a/lib/html/proofer/checkable.rb
+++ b/lib/html/proofer/checkable.rb
@@ -75,11 +75,6 @@ module HTML
         # ignore user defined URLs
         return true if ignores_pattern_check(@check.url_ignores)
 
-        # ignore user defined hrefs
-        if 'LinkCheckable' == @type
-          return true if ignores_pattern_check(@check.href_ignores)
-        end
-
         # ignore user defined alts
         if 'ImageCheckable' == @type
           return true if ignores_pattern_check(@check.alt_ignores)

--- a/lib/html/proofer/configuration.rb
+++ b/lib/html/proofer/configuration.rb
@@ -18,7 +18,6 @@ module HTML
         :ext => '.html',
         :external_only => false,
         :file_ignore => [],
-        :href_ignore => [],
         :href_swap => [],
         :only_4xx => false,
         :url_ignore => [],

--- a/lib/html/proofer/configuration.rb
+++ b/lib/html/proofer/configuration.rb
@@ -18,9 +18,9 @@ module HTML
         :ext => '.html',
         :external_only => false,
         :file_ignore => [],
-        :href_swap => [],
         :only_4xx => false,
         :url_ignore => [],
+        :url_swap => [],
         :verbose => false
       }
 

--- a/spec/html/proofer/command_spec.rb
+++ b/spec/html/proofer/command_spec.rb
@@ -50,9 +50,9 @@ describe 'Command test' do
     expect(output).to match('successfully')
   end
 
-  it 'works with href-ignore' do
+  it 'works with url-ignore' do
     ignorableLinks = "#{FIXTURES_DIR}/links/ignorableLinksViaOptions.html"
-    output = make_bin('--href-ignore /^http:\/\//,/sdadsad/,../whaadadt.html', ignorableLinks)
+    output = make_bin('--url-ignore /^http:\/\//,/sdadsad/,../whaadadt.html', ignorableLinks)
     expect(output).to match('successfully')
   end
 

--- a/spec/html/proofer/command_spec.rb
+++ b/spec/html/proofer/command_spec.rb
@@ -56,9 +56,9 @@ describe 'Command test' do
     expect(output).to match('successfully')
   end
 
-  it 'works with href-swap' do
+  it 'works with url-swap' do
     translatedLink = "#{FIXTURES_DIR}/links/linkTranslatedViaHrefSwap.html"
-    output = make_bin('--href-swap "\A/articles/([\w-]+):\1.html"', translatedLink)
+    output = make_bin('--url-swap "\A/articles/([\w-]+):\1.html"', translatedLink)
     expect(output).to match('successfully')
   end
 

--- a/spec/html/proofer/fixtures/vcr_cassettes/www_garbalarba_com_url_swap_/garbalarba/_github_.yml
+++ b/spec/html/proofer/fixtures/vcr_cassettes/www_garbalarba_com_url_swap_/garbalarba/_github_.yml
@@ -1,0 +1,74 @@
+---
+http_interactions:
+- request:
+    method: head
+    uri: www.github.com
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/2.6.1; +https://github.com/gjtorikian/html-proofer)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Wed, 23 Dec 2015 01:43:28 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Status:
+      - 200 OK
+      Cache-Control:
+      - no-cache
+      Vary:
+      - X-PJAX
+      - Accept-Encoding
+      X-UA-Compatible:
+      - IE=Edge,chrome=1
+      Set-Cookie:
+      - logged_in=no; domain=.github.com; path=/; expires=Sun, 23 Dec 2035 01:43:28
+        -0000; secure; HttpOnly
+      - _gh_sess=eyJzZXNzaW9uX2lkIjoiNTM5ODYwNjc2YzgwMzIwMjY3NDdkNWI5NmQ3OTAwMmIiLCJfY3NyZl90b2tlbiI6ImNkdkI5K0QzU3d4aGxIKy8yUDBhM2RlV3ZtT3Z1eDB2TWdWcVE0U2pzWnc9In0%3D--21d75dd02dd5083c0f9dd0c89bea56fca0045340;
+        path=/; secure; HttpOnly
+      X-Request-Id:
+      - 5c537e4545afd19b6111fd2b9971572f
+      X-Runtime:
+      - '0.015607'
+      Content-Security-Policy:
+      - 'default-src *; base-uri ''self''; connect-src ''self'' live.github.com wss://live.github.com
+        uploads.github.com status.github.com api.github.com www.google-analytics.com
+        api.braintreegateway.com client-analytics.braintreegateway.com github-cloud.s3.amazonaws.com;
+        font-src assets-cdn.github.com; form-action ''self'' github.com gist.github.com;
+        frame-src ''self'' render.githubusercontent.com gist.github.com www.youtube.com
+        player.vimeo.com checkout.paypal.com; img-src ''self'' data: assets-cdn.github.com
+        identicons.github.com www.google-analytics.com checkout.paypal.com collector.githubapp.com
+        *.githubusercontent.com *.gravatar.com *.wp.com; media-src ''none''; object-src
+        assets-cdn.github.com; script-src assets-cdn.github.com; style-src ''self''
+        ''unsafe-inline'' ''unsafe-eval'' assets-cdn.github.com'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Public-Key-Pins:
+      - max-age=300; pin-sha256="WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18="; pin-sha256="JbQbUG5JMJUoI6brnx0x3vZF6jilxsapbXGVfjhN8Fg=";
+        includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-XSS-Protection:
+      - 1; mode=block
+      X-Served-By:
+      - 7d2a2d05162492046d9960cdbc326796
+      X-GitHub-Request-Id:
+      - BDBE5267:448B:2557B0EC:5679FC40
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://github.com/
+  recorded_at: Wed, 23 Dec 2015 01:43:28 GMT
+recorded_with: VCR 2.9.3

--- a/spec/html/proofer/links_spec.rb
+++ b/spec/html/proofer/links_spec.rb
@@ -131,9 +131,9 @@ describe 'Links test' do
     expect(proofer.failed_tests).to eq []
   end
 
-  it 'ignores links via href_ignore' do
+  it 'ignores links via url_ignore' do
     ignorableLinks = "#{FIXTURES_DIR}/links/ignorableLinksViaOptions.html"
-    proofer = run_proofer(ignorableLinks, { :href_ignore => [%r{^http://}, /sdadsad/, '../whaadadt.html'] })
+    proofer = run_proofer(ignorableLinks, { :url_ignore => [%r{^http://}, /sdadsad/, '../whaadadt.html'] })
     expect(proofer.failed_tests).to eq []
   end
 

--- a/spec/html/proofer/links_spec.rb
+++ b/spec/html/proofer/links_spec.rb
@@ -137,14 +137,14 @@ describe 'Links test' do
     expect(proofer.failed_tests).to eq []
   end
 
-  it 'translates links via href_swap' do
+  it 'translates links via url_swap' do
     translatedLink = "#{FIXTURES_DIR}/links/linkTranslatedViaHrefSwap.html"
-    proofer = run_proofer(translatedLink, { :href_swap => { %r{\A/articles/([\w-]+)} => "\\1.html" } })
+    proofer = run_proofer(translatedLink, { :url_swap => { %r{\A/articles/([\w-]+)} => "\\1.html" } })
     expect(proofer.failed_tests).to eq []
   end
 
-  it 'translates links via href_swap for list of links' do
-    proofer = run_proofer(['www.garbalarba.com'], { :href_swap => { /garbalarba/ => 'github' } })
+  it 'translates links via url_swap for list of links' do
+    proofer = run_proofer(['www.garbalarba.com'], { :url_swap => { /garbalarba/ => 'github' } })
     expect(proofer.failed_tests).to eq []
   end
 


### PR DESCRIPTION
Closes https://github.com/gjtorikian/html-proofer/issues/219, closes https://github.com/gjtorikian/html-proofer/issues/214.

The URL versions are more generic, and should act on more than just `href` elements.