### PR TITLE
Drop href ignore/swap in favor of url ignore/swap

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ You'll get a new program called `htmlproof` with this gem. Terrific!
 Use it like you'd expect to:
 
 ``` bash
-htmlproof ./out --href-swap wow:cow,mow:doh --ext .html.erb --href-ignore www.github.com
+htmlproof ./out --href-swap wow:cow,mow:doh --ext .html.erb --url-ignore www.github.com
 ```
 
 Note: since `href_swap` is a bit special, you'll pass in a pair of `RegEx:String` values.
@@ -168,7 +168,6 @@ The `HTML::Proofer` constructor takes an optional hash of additional options:
 | `ext` | The extension of your HTML files including the dot. | `.html`
 | `external_only` | Only checks problems with external references. | `false`
 | `file_ignore` | An array of Strings or RegExps containing file paths that are safe to ignore. | `[]` |
-| `href_ignore` | An array of Strings or RegExps containing `href`s that are safe to ignore. Note that non-HTTP(S) URIs are always ignored. **Will be renamed in a future release.** | `[]` |
 | `href_swap` | A hash containing key-value pairs of `RegExp => String`. It transforms links that match `RegExp` into `String` via `gsub`. **Will be renamed in a future release.** | `{}` |
 | `only_4xx` | Only reports errors for links that fall within the 4xx status code range. | `false` |
 | `url_ignore` | An array of Strings or RegExps containing URLs that are safe to ignore. It affects all HTML attributes. Note that non-HTTP(S) URIs are always ignored. | `[]` |

--- a/README.md
+++ b/README.md
@@ -99,10 +99,10 @@ You'll get a new program called `htmlproof` with this gem. Terrific!
 Use it like you'd expect to:
 
 ``` bash
-htmlproof ./out --href-swap wow:cow,mow:doh --ext .html.erb --url-ignore www.github.com
+htmlproof ./out --url-swap wow:cow,mow:doh --ext .html.erb --url-ignore www.github.com
 ```
 
-Note: since `href_swap` is a bit special, you'll pass in a pair of `RegEx:String` values.
+Note: since `url_swap` is a bit special, you'll pass in a pair of `RegEx:String` values.
 `htmlproof` will figure out what you mean.
 
 ### Using with Jekyll
@@ -168,9 +168,9 @@ The `HTML::Proofer` constructor takes an optional hash of additional options:
 | `ext` | The extension of your HTML files including the dot. | `.html`
 | `external_only` | Only checks problems with external references. | `false`
 | `file_ignore` | An array of Strings or RegExps containing file paths that are safe to ignore. | `[]` |
-| `href_swap` | A hash containing key-value pairs of `RegExp => String`. It transforms links that match `RegExp` into `String` via `gsub`. **Will be renamed in a future release.** | `{}` |
 | `only_4xx` | Only reports errors for links that fall within the 4xx status code range. | `false` |
 | `url_ignore` | An array of Strings or RegExps containing URLs that are safe to ignore. It affects all HTML attributes. Note that non-HTTP(S) URIs are always ignored. | `[]` |
+| `url_swap` | A hash containing key-value pairs of `RegExp => String`. It transforms URLs that match `RegExp` into `String` via `gsub`. | `{}` |
 | `verbose` | If `true`, outputs extra information as the checking happens. Useful for debugging. **Will be deprecated in a future release.**| `false` |
 | `verbosity` | Sets the logging level, as determined by [Yell](https://github.com/rudionrails/yell). | `:info`
 

--- a/bin/htmlproof
+++ b/bin/htmlproof
@@ -28,10 +28,10 @@ Mercenary.program(:htmlproof) do |p|
   p.option 'ext', '--ext EXT', String, 'The extension of your HTML files including the dot. (default: `.html`)'
   p.option 'external_only', '--external_only', 'Only checks problems with external references'
   p.option 'file_ignore', '--file-ignore file1,[file2,...]', Array, 'A comma-separated list of Strings or RegExps containing file paths that are safe to ignore'
-  p.option 'href_swap', '--href-swap re:string,[re:string,...]', Array, 'A comma-separated list containing key-value pairs of `RegExp => String`. It transforms links that match `RegExp` into `String` via `gsub`. **Will be renamed in a future release.**'
   p.option 'ignore_script_embeds', '--ignore-script-embeds', 'Ignore `check_html` errors associated with `script`s (default: `false`)'
   p.option 'only_4xx', '--only-4xx', 'Only reports errors for links that fall within the 4xx status code range'
   p.option 'url_ignore', '--url-ignore link1,[link2,...]', Array, 'A comma-separated list of Strings or RegExps containing URLs that are safe to ignore. It affects all HTML attributes. Note that non-HTTP(S) URIs are always ignored'
+  p.option 'url_swap', '--url-swap re:string,[re:string,...]', Array, 'A comma-separated list containing key-value pairs of `RegExp => String`. It transforms URLs that match `RegExp` into `String` via `gsub`.'
   p.option 'verbose', '--verbose', 'If `true`, outputs extra information as the checking happens. Useful for debugging. **Will be deprecated in a future release.**'
   p.option 'verbosity', '--verbosity', String, 'Sets the logging level, as determined by Yell'
 
@@ -50,11 +50,11 @@ Mercenary.program(:htmlproof) do |p|
     end
 
     # some minor manipulation of a special option
-    unless opts['href_swap'].nil?
-      options[:href_swap] = {}
-      opts['href_swap'].each do |s|
+    unless opts['url_swap'].nil?
+      options[:url_swap] = {}
+      opts['url_swap'].each do |s|
         pair = s.split(':', 2)
-        options[:href_swap][Regexp.new(pair[0])] = pair[1]
+        options[:url_swap][Regexp.new(pair[0])] = pair[1]
       end
     end
 

--- a/bin/htmlproof
+++ b/bin/htmlproof
@@ -28,7 +28,6 @@ Mercenary.program(:htmlproof) do |p|
   p.option 'ext', '--ext EXT', String, 'The extension of your HTML files including the dot. (default: `.html`)'
   p.option 'external_only', '--external_only', 'Only checks problems with external references'
   p.option 'file_ignore', '--file-ignore file1,[file2,...]', Array, 'A comma-separated list of Strings or RegExps containing file paths that are safe to ignore'
-  p.option 'href_ignore', '--href-ignore link1,[link2,...]', Array, 'A comma-separated list of Strings or RegExps containing `href`s that are safe to ignore. Note that non-HTTP(S) URIs are always ignored. **Will be renamed in a future release.**'
   p.option 'href_swap', '--href-swap re:string,[re:string,...]', Array, 'A comma-separated list containing key-value pairs of `RegExp => String`. It transforms links that match `RegExp` into `String` via `gsub`. **Will be renamed in a future release.**'
   p.option 'ignore_script_embeds', '--ignore-script-embeds', 'Ignore `check_html` errors associated with `script`s (default: `false`)'
   p.option 'only_4xx', '--only-4xx', 'Only reports errors for links that fall within the 4xx status code range'

--- a/lib/html/proofer.rb
+++ b/lib/html/proofer.rb
@@ -30,9 +30,6 @@ module HTML
       if opts[:verbose]
         warn '`@options[:verbose]` will be removed in a future 3.x.x release: http://git.io/vGHHh'
       end
-      if opts[:href_ignore]
-        warn '`@options[:href_ignore]` will be renamed in a future 3.x.x release: http://git.io/vGHHy'
-      end
 
       @proofer_opts = HTML::Proofer::Configuration::PROOFER_DEFAULTS
 

--- a/lib/html/proofer.rb
+++ b/lib/html/proofer.rb
@@ -72,9 +72,9 @@ module HTML
     end
 
     def check_list_of_links
-      if @options[:href_swap]
+      if @options[:url_swap]
         @src = @src.map do |url|
-          swap(url, @options[:href_swap])
+          swap(url, @options[:url_swap])
         end
       end
       @external_urls = Hash[*@src.map { |s| [s, nil] }.flatten]

--- a/lib/html/proofer/check_runner.rb
+++ b/lib/html/proofer/check_runner.rb
@@ -6,7 +6,7 @@ module HTML
     class CheckRunner
 
       attr_reader :issues, :src, :path, :options, :typhoeus_opts, :hydra_opts, :parallel_opts, \
-                  :validation_opts, :external_urls, :href_ignores, :url_ignores, :alt_ignores, \
+                  :validation_opts, :external_urls, :url_ignores, :alt_ignores, \
                   :empty_alt_ignore, :allow_hash_href
 
       def initialize(src, path, html, options, typhoeus_opts, hydra_opts, parallel_opts, validation_opts)
@@ -19,7 +19,6 @@ module HTML
         @parallel_opts = parallel_opts
         @validation_opts = validation_opts
         @issues = []
-        @href_ignores = @options[:href_ignore]
         @url_ignores = @options[:url_ignore]
         @alt_ignores = @options[:alt_ignore]
         @empty_alt_ignore = @options[:empty_alt_ignore]

--- a/lib/html/proofer/checkable.rb
+++ b/lib/html/proofer/checkable.rb
@@ -20,8 +20,8 @@ module HTML
         @type = self.class.name
         @line = obj.line
 
-        if @href && @check.options[:href_swap]
-          @href = swap(@href, @check.options[:href_swap])
+        if @href && @check.options[:url_swap]
+          @href = swap(@href, @check.options[:url_swap])
         end
 
         # fix up missing protocols

--- a/lib/html/proofer/checkable.rb
+++ b/lib/html/proofer/checkable.rb
@@ -75,11 +75,6 @@ module HTML
         # ignore user defined URLs
         return true if ignores_pattern_check(@check.url_ignores)
 
-        # ignore user defined hrefs
-        if 'LinkCheckable' == @type
-          return true if ignores_pattern_check(@check.href_ignores)
-        end
-
         # ignore user defined alts
         if 'ImageCheckable' == @type
           return true if ignores_pattern_check(@check.alt_ignores)

--- a/lib/html/proofer/checkable.rb
+++ b/lib/html/proofer/checkable.rb
@@ -76,9 +76,8 @@ module HTML
         return true if ignores_pattern_check(@check.url_ignores)
 
         # ignore user defined alts
-        if 'ImageCheckable' == @type
-          return true if ignores_pattern_check(@check.alt_ignores)
-        end
+        return false unless 'ImageCheckable' == @type
+        return true if ignores_pattern_check(@check.alt_ignores)
       end
 
       def ignore_empty_alt?

--- a/lib/html/proofer/checkable.rb
+++ b/lib/html/proofer/checkable.rb
@@ -20,17 +20,16 @@ module HTML
         @type = self.class.name
         @line = obj.line
 
-        if @href && @check.options[:url_swap]
-          @href = swap(@href, @check.options[:url_swap])
-        end
-
         # fix up missing protocols
         @href.insert 0, 'http:' if @href =~ %r{^//}
         @src.insert 0, 'http:' if @src =~ %r{^//}
       end
 
       def url
-        @src || @srcset || @href || ''
+        url = @src || @srcset || @href || ''
+        return url if @check.nil?
+        return url unless @check.options[:url_swap]
+        swap(url, @check.options[:url_swap])
       end
 
       def valid?
@@ -154,8 +153,8 @@ module HTML
 
       private
 
-      def real_attr(attr)
-        attr.to_s unless attr.nil? || attr.empty?
+      def blank?(attr)
+        attr.nil? || attr.empty?
       end
     end
   end

--- a/lib/html/proofer/checks/favicon.rb
+++ b/lib/html/proofer/checks/favicon.rb
@@ -9,7 +9,7 @@ class FaviconCheck < ::HTML::Proofer::CheckRunner
     found = false
     @html.xpath('//link[not(ancestor::pre or ancestor::code)]').each do |node|
       favicon = FaviconCheckable.new(node, self)
-      next if favicon.ignore?
+      found = true if favicon.ignore?
       found = true if favicon.rel.split(' ').last.eql? 'icon'
       break if found
     end

--- a/lib/html/proofer/checks/favicon.rb
+++ b/lib/html/proofer/checks/favicon.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class FaviconCheckable < ::HTML::Proofer::Checkable
   attr_reader :rel
 end
@@ -9,7 +7,7 @@ class FaviconCheck < ::HTML::Proofer::CheckRunner
     found = false
     @html.xpath('//link[not(ancestor::pre or ancestor::code)]').each do |node|
       favicon = FaviconCheckable.new(node, self)
-      found = true if favicon.ignore?
+      next if favicon.ignore?
       found = true if favicon.rel.split(' ').last.eql? 'icon'
       break if found
     end

--- a/lib/html/proofer/checks/images.rb
+++ b/lib/html/proofer/checks/images.rb
@@ -10,15 +10,11 @@ class ImageCheckable < ::HTML::Proofer::Checkable
   end
 
   def terrible_filename?
-    src =~ SCREEN_SHOT_REGEX
-  end
-
-  def src
-    real_attr(@src) || real_attr(@srcset)
+    url =~ SCREEN_SHOT_REGEX
   end
 
   def missing_src?
-    !src
+    url.nil? || url.empty?
   end
 end
 
@@ -31,21 +27,21 @@ class ImageCheck < ::HTML::Proofer::CheckRunner
       next if img.ignore?
 
       # screenshot filenames should return because of terrible names
-      next add_issue("image has a terrible filename (#{img.src})", line) if img.terrible_filename?
+      next add_issue("image has a terrible filename (#{img.url})", line) if img.terrible_filename?
 
       # does the image exist?
       if img.missing_src?
         add_issue('image has no src or srcset attribute', line)
       else
         if img.remote?
-          add_to_external_urls(img.src, line)
+          add_to_external_urls(img.url, line)
         else
-          add_issue("internal image #{img.src} does not exist", line) unless img.exists?
+          add_issue("internal image #{img.url} does not exist", line) unless img.exists?
         end
       end
 
       if img.alt.nil? || (img.empty_alt_tag? && !img.ignore_empty_alt?)
-        add_issue("image #{img.src} does not have an alt attribute", line)
+        add_issue("image #{img.url} does not have an alt attribute", line)
       end
     end
 

--- a/lib/html/proofer/checks/links.rb
+++ b/lib/html/proofer/checks/links.rb
@@ -1,23 +1,12 @@
 class LinkCheckable < ::HTML::Proofer::Checkable
-
-  def href
-    real_attr @href
-  end
-
-  def id
-    real_attr @id
-  end
-
-  def name
-    real_attr @name
-  end
+  attr_reader :href, :id, :name
 
   def missing_href?
-    href.nil? && name.nil? && id.nil?
+    blank?(href) && blank?(name) && blank?(id)
   end
 
   def placeholder?
-    (id || name) && href.nil?
+    (!blank?(id) || !blank?(name)) && href.nil?
   end
 end
 

--- a/lib/html/proofer/checks/scripts.rb
+++ b/lib/html/proofer/checks/scripts.rb
@@ -1,10 +1,5 @@
-# encoding: utf-8
-
 class ScriptCheckable < ::HTML::Proofer::Checkable
-
-  def src
-    real_attr @src
-  end
+  attr_reader :src
 
   def missing_src?
     !src

--- a/lib/html/proofer/configuration.rb
+++ b/lib/html/proofer/configuration.rb
@@ -18,7 +18,6 @@ module HTML
         :ext => '.html',
         :external_only => false,
         :file_ignore => [],
-        :href_ignore => [],
         :href_swap => [],
         :only_4xx => false,
         :url_ignore => [],

--- a/lib/html/proofer/configuration.rb
+++ b/lib/html/proofer/configuration.rb
@@ -18,9 +18,9 @@ module HTML
         :ext => '.html',
         :external_only => false,
         :file_ignore => [],
-        :href_swap => [],
         :only_4xx => false,
         :url_ignore => [],
+        :url_swap => [],
         :verbose => false
       }
 

--- a/spec/html/proofer/command_spec.rb
+++ b/spec/html/proofer/command_spec.rb
@@ -50,9 +50,9 @@ describe 'Command test' do
     expect(output).to match('successfully')
   end
 
-  it 'works with href-ignore' do
+  it 'works with url-ignore' do
     ignorableLinks = "#{FIXTURES_DIR}/links/ignorableLinksViaOptions.html"
-    output = make_bin('--href-ignore /^http:\/\//,/sdadsad/,../whaadadt.html', ignorableLinks)
+    output = make_bin('--url-ignore /^http:\/\//,/sdadsad/,../whaadadt.html', ignorableLinks)
     expect(output).to match('successfully')
   end
 

--- a/spec/html/proofer/command_spec.rb
+++ b/spec/html/proofer/command_spec.rb
@@ -56,9 +56,9 @@ describe 'Command test' do
     expect(output).to match('successfully')
   end
 
-  it 'works with href-swap' do
+  it 'works with url-swap' do
     translatedLink = "#{FIXTURES_DIR}/links/linkTranslatedViaHrefSwap.html"
-    output = make_bin('--href-swap "\A/articles/([\w-]+):\1.html"', translatedLink)
+    output = make_bin('--url-swap "\A/articles/([\w-]+):\1.html"', translatedLink)
     expect(output).to match('successfully')
   end
 

--- a/spec/html/proofer/favicon_spec.rb
+++ b/spec/html/proofer/favicon_spec.rb
@@ -25,10 +25,16 @@ describe 'Favicons test' do
     expect(proofer.failed_tests.first).to match(/internally linking to asdadaskdalsdk.png/)
   end
 
-  it 'ignores with url_ignore' do
+  it 'fails for ignored with url_ignore' do
     ignored = "#{FIXTURES_DIR}/favicon/favicon_broken.html"
     proofer = run_proofer(ignored, { :check_favicon => true, :url_ignore => [/asdadaskdalsdk/] })
-    expect(proofer.failed_tests.length).to eq 0
+    expect(proofer.failed_tests.first).to match(/no favicon specified/)
+  end
+
+  it 'translates links via url_swap' do
+    translatedLink = "#{FIXTURES_DIR}/favicon/favicon_broken.html"
+    proofer = run_proofer(translatedLink, { :check_favicon => true, :url_swap => { /^asdadaskdalsdk.+/ => '../resources/gpl.png' } })
+    expect(proofer.failed_tests).to eq []
   end
 
   it 'passes for present favicon' do

--- a/spec/html/proofer/favicon_spec.rb
+++ b/spec/html/proofer/favicon_spec.rb
@@ -22,8 +22,13 @@ describe 'Favicons test' do
   it 'fails for broken favicon' do
     broken = "#{FIXTURES_DIR}/favicon/favicon_broken.html"
     proofer = run_proofer(broken, { :check_favicon => true })
-
     expect(proofer.failed_tests.first).to match(/internally linking to asdadaskdalsdk.png/)
+  end
+
+  it 'ignores with url_ignore' do
+    ignored = "#{FIXTURES_DIR}/favicon/favicon_broken.html"
+    proofer = run_proofer(ignored, { :check_favicon => true, :url_ignore => [/asdadaskdalsdk/] })
+    expect(proofer.failed_tests.length).to eq 0
   end
 
   it 'passes for present favicon' do

--- a/spec/html/proofer/fixtures/vcr_cassettes/www_garbalarba_com_url_swap_/garbalarba/_github_.yml
+++ b/spec/html/proofer/fixtures/vcr_cassettes/www_garbalarba_com_url_swap_/garbalarba/_github_.yml
@@ -1,0 +1,74 @@
+---
+http_interactions:
+- request:
+    method: head
+    uri: www.github.com
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/2.6.1; +https://github.com/gjtorikian/html-proofer)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Wed, 23 Dec 2015 01:43:28 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Status:
+      - 200 OK
+      Cache-Control:
+      - no-cache
+      Vary:
+      - X-PJAX
+      - Accept-Encoding
+      X-UA-Compatible:
+      - IE=Edge,chrome=1
+      Set-Cookie:
+      - logged_in=no; domain=.github.com; path=/; expires=Sun, 23 Dec 2035 01:43:28
+        -0000; secure; HttpOnly
+      - _gh_sess=eyJzZXNzaW9uX2lkIjoiNTM5ODYwNjc2YzgwMzIwMjY3NDdkNWI5NmQ3OTAwMmIiLCJfY3NyZl90b2tlbiI6ImNkdkI5K0QzU3d4aGxIKy8yUDBhM2RlV3ZtT3Z1eDB2TWdWcVE0U2pzWnc9In0%3D--21d75dd02dd5083c0f9dd0c89bea56fca0045340;
+        path=/; secure; HttpOnly
+      X-Request-Id:
+      - 5c537e4545afd19b6111fd2b9971572f
+      X-Runtime:
+      - '0.015607'
+      Content-Security-Policy:
+      - 'default-src *; base-uri ''self''; connect-src ''self'' live.github.com wss://live.github.com
+        uploads.github.com status.github.com api.github.com www.google-analytics.com
+        api.braintreegateway.com client-analytics.braintreegateway.com github-cloud.s3.amazonaws.com;
+        font-src assets-cdn.github.com; form-action ''self'' github.com gist.github.com;
+        frame-src ''self'' render.githubusercontent.com gist.github.com www.youtube.com
+        player.vimeo.com checkout.paypal.com; img-src ''self'' data: assets-cdn.github.com
+        identicons.github.com www.google-analytics.com checkout.paypal.com collector.githubapp.com
+        *.githubusercontent.com *.gravatar.com *.wp.com; media-src ''none''; object-src
+        assets-cdn.github.com; script-src assets-cdn.github.com; style-src ''self''
+        ''unsafe-inline'' ''unsafe-eval'' assets-cdn.github.com'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Public-Key-Pins:
+      - max-age=300; pin-sha256="WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18="; pin-sha256="JbQbUG5JMJUoI6brnx0x3vZF6jilxsapbXGVfjhN8Fg=";
+        includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-XSS-Protection:
+      - 1; mode=block
+      X-Served-By:
+      - 7d2a2d05162492046d9960cdbc326796
+      X-GitHub-Request-Id:
+      - BDBE5267:448B:2557B0EC:5679FC40
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://github.com/
+  recorded_at: Wed, 23 Dec 2015 01:43:28 GMT
+recorded_with: VCR 2.9.3

--- a/spec/html/proofer/fixtures/vcr_cassettes/www_garbalarba_com_url_swap_/garbalarba/_github_.yml
+++ b/spec/html/proofer/fixtures/vcr_cassettes/www_garbalarba_com_url_swap_/garbalarba/_github_.yml
@@ -71,4 +71,25 @@ http_interactions:
     adapter_metadata:
       effective_url: https://github.com/
   recorded_at: Wed, 23 Dec 2015 01:43:28 GMT
+- request:
+    method: head
+    uri: www.garbalarba.com
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/2.6.1; +https://github.com/gjtorikian/html-proofer)
+  response:
+    status:
+      code: 0
+      message: 
+    headers: {}
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+    adapter_metadata:
+      effective_url: HTTP://www.garbalarba.com/
+  recorded_at: Wed, 23 Dec 2015 18:51:29 GMT
 recorded_with: VCR 2.9.3

--- a/spec/html/proofer/images_spec.rb
+++ b/spec/html/proofer/images_spec.rb
@@ -62,6 +62,12 @@ describe 'Images test' do
     expect(proofer.failed_tests).to eq []
   end
 
+  it 'ignores images via url_ignore' do
+    ignorableImage = "#{FIXTURES_DIR}/links/terribleImageName.html"
+    proofer = run_proofer(ignorableImage, { :url_ignore => [/^Screen/] })
+    expect(proofer.failed_tests).to eq []
+  end
+
   it 'properly checks relative images' do
     relativeImages = "#{FIXTURES_DIR}/images/rootRelativeImages.html"
     proofer = run_proofer(relativeImages)

--- a/spec/html/proofer/images_spec.rb
+++ b/spec/html/proofer/images_spec.rb
@@ -63,8 +63,14 @@ describe 'Images test' do
   end
 
   it 'ignores images via url_ignore' do
-    ignorableImage = "#{FIXTURES_DIR}/links/terribleImageName.html"
-    proofer = run_proofer(ignorableImage, { :url_ignore => [/^Screen/] })
+    ignorableImage = "#{FIXTURES_DIR}/images/terribleImageName.html"
+    proofer = run_proofer(ignorableImage, { :url_ignore => [%r{./Screen.+}] })
+    expect(proofer.failed_tests).to eq []
+  end
+
+  it 'translates images via url_swap' do
+    translatedLink = "#{FIXTURES_DIR}/images/terribleImageName.html"
+    proofer = run_proofer(translatedLink, { :url_swap => { %r{./Screen.+} => 'gpl.png' } })
     expect(proofer.failed_tests).to eq []
   end
 

--- a/spec/html/proofer/links_spec.rb
+++ b/spec/html/proofer/links_spec.rb
@@ -131,9 +131,9 @@ describe 'Links test' do
     expect(proofer.failed_tests).to eq []
   end
 
-  it 'ignores links via href_ignore' do
+  it 'ignores links via url_ignore' do
     ignorableLinks = "#{FIXTURES_DIR}/links/ignorableLinksViaOptions.html"
-    proofer = run_proofer(ignorableLinks, { :href_ignore => [%r{^http://}, /sdadsad/, '../whaadadt.html'] })
+    proofer = run_proofer(ignorableLinks, { :url_ignore => [%r{^http://}, /sdadsad/, '../whaadadt.html'] })
     expect(proofer.failed_tests).to eq []
   end
 

--- a/spec/html/proofer/links_spec.rb
+++ b/spec/html/proofer/links_spec.rb
@@ -137,14 +137,14 @@ describe 'Links test' do
     expect(proofer.failed_tests).to eq []
   end
 
-  it 'translates links via href_swap' do
+  it 'translates links via url_swap' do
     translatedLink = "#{FIXTURES_DIR}/links/linkTranslatedViaHrefSwap.html"
-    proofer = run_proofer(translatedLink, { :href_swap => { %r{\A/articles/([\w-]+)} => "\\1.html" } })
+    proofer = run_proofer(translatedLink, { :url_swap => { %r{\A/articles/([\w-]+)} => "\\1.html" } })
     expect(proofer.failed_tests).to eq []
   end
 
-  it 'translates links via href_swap for list of links' do
-    proofer = run_proofer(['www.garbalarba.com'], { :href_swap => { /garbalarba/ => 'github' } })
+  it 'translates links via url_swap for list of links' do
+    proofer = run_proofer(['www.garbalarba.com'], { :url_swap => { /garbalarba/ => 'github' } })
     expect(proofer.failed_tests).to eq []
   end
 


### PR DESCRIPTION
Closes https://github.com/gjtorikian/html-proofer/issues/219, closes https://github.com/gjtorikian/html-proofer/issues/214.

The URL versions are more generic, and should act on more than just `href` elements.