### PR TITLE
Allow extensionless URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ The `HTML::Proofer` constructor takes an optional hash of additional options:
 | :----- | :---------- | :------ |
 | `allow_hash_href` | If `true`, ignores the `href` `#`. | `false` |
 | `alt_ignore` | An array of Strings or RegExps containing `img`s whose missing `alt` tags are safe to ignore. | `[]` |
+| `assume_extension` | Automatically add extension (e.g. `.html`) to file paths, to allow extensionless URLs (as supported by Jekyll 3 and Github Pages) | `nil` |
 | `check_external_hash` | Checks whether external hashes exist (even if the website exists). This slows the checker down. | `false` |
 | `check_favicon` | Enables the favicon checker. | `false` |
 | `check_html` | Enables HTML validation errors from Nokogiri | `false` |

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ The `HTML::Proofer` constructor takes an optional hash of additional options:
 | :----- | :---------- | :------ |
 | `allow_hash_href` | If `true`, ignores the `href` `#`. | `false` |
 | `alt_ignore` | An array of Strings or RegExps containing `img`s whose missing `alt` tags are safe to ignore. | `[]` |
-| `assume_extension` | Automatically add extension (e.g. `.html`) to file paths, to allow extensionless URLs (as supported by Jekyll 3 and Github Pages) | `nil` |
+| `assume_extension` | Automatically add extension (e.g. `.html`) to file paths, to allow extensionless URLs (as supported by Jekyll 3 and GitHub Pages) | `nil` |
 | `check_external_hash` | Checks whether external hashes exist (even if the website exists). This slows the checker down. | `false` |
 | `check_favicon` | Enables the favicon checker. | `false` |
 | `check_html` | Enables HTML validation errors from Nokogiri | `false` |

--- a/bin/htmlproof
+++ b/bin/htmlproof
@@ -16,7 +16,7 @@ Mercenary.program(:htmlproof) do |p|
   p.option 'allow_hash_href', '--allow-hash-href', 'If `true`, ignores the `href` `#`'
   p.option 'as_links', '--as-links', 'Assumes that `PATH` is a comma-separated array of links to check.'
   p.option 'alt_ignore', '--alt-ignore image1,[image2,...]', Array, 'A comma-separated list of Strings or RegExps containing `img`s whose missing `alt` tags are safe to ignore'
-  p.option 'assume_extension', '--assume-extension', 'Automatically add extension (e.g. `.html`) to file paths, to allow extensionless URLs (as supported by Jekyll 3 and Github Pages) (default: `nil`).'
+  p.option 'assume_extension', '--assume-extension', 'Automatically add extension (e.g. `.html`) to file paths, to allow extensionless URLs (as supported by Jekyll 3 and GitHub Pages) (default: `nil`).'
   p.option 'checks_to_ignore', '--checks-to-ignore check1,[check2,...]', Array, ' An array of Strings indicating which checks you\'d like to not perform.'
   p.option 'check_external_hash', '--check-external-hash', 'Checks whether external hashes exist (even if the website exists). This slows the checker down (default: `false`).'
   p.option 'check_favicon', '--check-favicon', 'Enables the favicon checker (default: `false`).'

--- a/bin/htmlproof
+++ b/bin/htmlproof
@@ -16,6 +16,7 @@ Mercenary.program(:htmlproof) do |p|
   p.option 'allow_hash_href', '--allow-hash-href', 'If `true`, ignores the `href` `#`'
   p.option 'as_links', '--as-links', 'Assumes that `PATH` is a comma-separated array of links to check.'
   p.option 'alt_ignore', '--alt-ignore image1,[image2,...]', Array, 'A comma-separated list of Strings or RegExps containing `img`s whose missing `alt` tags are safe to ignore'
+  p.option 'assume_extension', '--assume-extension', 'Automatically add extension (e.g. `.html`) to file paths, to allow extensionless URLs (as supported by Jekyll 3 and Github Pages) (default: `nil`).'
   p.option 'checks_to_ignore', '--checks-to-ignore check1,[check2,...]', Array, ' An array of Strings indicating which checks you\'d like to not perform.'
   p.option 'check_external_hash', '--check-external-hash', 'Checks whether external hashes exist (even if the website exists). This slows the checker down (default: `false`).'
   p.option 'check_favicon', '--check-favicon', 'Enables the favicon checker (default: `false`).'

--- a/lib/html/proofer/checkable.rb
+++ b/lib/html/proofer/checkable.rb
@@ -122,6 +122,8 @@ module HTML
         # implicit index support
         if File.directory?(file) && !unslashed_directory?(file)
           file = File.join file, @check.options[:directory_index_file]
+        elsif File.file?("#{file}.html")
+          file = "#{file}.html"
         end
 
         file

--- a/lib/html/proofer/checkable.rb
+++ b/lib/html/proofer/checkable.rb
@@ -111,7 +111,7 @@ module HTML
 
         if path =~ %r{^/} # path relative to root
           base = File.directory?(@check.src) ? @check.src : File.dirname(@check.src)
-        elsif File.exist?(File.expand_path path, @check.src) || File.exist?(File.expand_path path_dot_ext, @check.src) # relative links, path is a file
+        elsif File.exist?(File.expand_path(path, @check.src)) || File.exist?(File.expand_path(path_dot_ext, @check.src)) # relative links, path is a file
           base = File.dirname @check.path
         elsif File.exist?(File.join(File.dirname(@check.path), path)) || File.exist?(File.join(File.dirname(@check.path), path_dot_ext)) # relative links in nested dir, path is a file
           base = File.dirname @check.path

--- a/lib/html/proofer/checkable.rb
+++ b/lib/html/proofer/checkable.rb
@@ -124,8 +124,8 @@ module HTML
         # implicit index support
         if File.directory?(file) && !unslashed_directory?(file)
           file = File.join file, @check.options[:directory_index_file]
-        elsif File.file?("#{file}.html")
-          file = "#{file}.html"
+        elsif File.file?("#{file}#{@check.options[:assume_extension]}")
+          file = "#{file}#{@check.options[:assume_extension]}"
         end
 
         file

--- a/lib/html/proofer/checkable.rb
+++ b/lib/html/proofer/checkable.rb
@@ -107,14 +107,14 @@ module HTML
       def file_path
         return if path.nil?
 
-        auto_html_extension = true # This will be a command-line switch
-        path_dot_html = auto_html_extension ? path + ".html" : path
+        auto_extension = true # This will be a command-line switch
+        path_dot_ext = auto_extension ? path + @check.options[:ext] : path
 
         if path =~ %r{^/} # path relative to root
           base = File.directory?(@check.src) ? @check.src : File.dirname(@check.src)
-        elsif File.exist?(File.expand_path path, @check.src) || File.exist?(File.expand_path path_dot_html, @check.src) # relative links, path is a file
+        elsif File.exist?(File.expand_path path, @check.src) || File.exist?(File.expand_path path_dot_ext, @check.src) # relative links, path is a file
           base = File.dirname @check.path
-        elsif File.exist?(File.join(File.dirname(@check.path), path)) || File.exist?(File.join(File.dirname(@check.path), path_dot_html)) # relative links in nested dir, path is a file
+        elsif File.exist?(File.join(File.dirname(@check.path), path)) || File.exist?(File.join(File.dirname(@check.path), path_dot_ext)) # relative links in nested dir, path is a file
           base = File.dirname @check.path
         else # relative link, path is a directory
           base = @check.path

--- a/lib/html/proofer/checkable.rb
+++ b/lib/html/proofer/checkable.rb
@@ -107,8 +107,7 @@ module HTML
       def file_path
         return if path.nil?
 
-        auto_extension = true # This will be a command-line switch
-        path_dot_ext = auto_extension ? path + @check.options[:ext] : path
+        path_dot_ext = path + @check.options[:assume_extension].to_s
 
         if path =~ %r{^/} # path relative to root
           base = File.directory?(@check.src) ? @check.src : File.dirname(@check.src)

--- a/lib/html/proofer/checkable.rb
+++ b/lib/html/proofer/checkable.rb
@@ -107,11 +107,14 @@ module HTML
       def file_path
         return if path.nil?
 
+        auto_html_extension = true # This will be a command-line switch
+        path_dot_html = auto_html_extension ? path + ".html" : path
+
         if path =~ %r{^/} # path relative to root
           base = File.directory?(@check.src) ? @check.src : File.dirname(@check.src)
-        elsif File.exist?(File.expand_path path, @check.src) # relative links, path is a file
+        elsif File.exist?(File.expand_path path, @check.src) || File.exist?(File.expand_path path_dot_html, @check.src) # relative links, path is a file
           base = File.dirname @check.path
-        elsif File.exist?(File.join(File.dirname(@check.path), path)) # relative links in nested dir, path is a file
+        elsif File.exist?(File.join(File.dirname(@check.path), path)) || File.exist?(File.join(File.dirname(@check.path), path_dot_html)) # relative links in nested dir, path is a file
           base = File.dirname @check.path
         else # relative link, path is a directory
           base = @check.path

--- a/lib/html/proofer/configuration.rb
+++ b/lib/html/proofer/configuration.rb
@@ -6,6 +6,7 @@ module HTML
       PROOFER_DEFAULTS = {
         :allow_hash_href => false,
         :alt_ignore => [],
+        :assume_extension => nil,
         :check_external_hash => false,
         :check_favicon => false,
         :check_html => false,

--- a/spec/html/proofer/fixtures/links/no_html_extension.html
+++ b/spec/html/proofer/fixtures/links/no_html_extension.html
@@ -1,0 +1,3 @@
+<a href="/anchors_in_pre">Relative to root</a>
+<a href="anchors_in_pre">Relative to self</a>
+<a href="anchors_in_pre#anchor">Anchor relative to self</a>

--- a/spec/html/proofer/links_spec.rb
+++ b/spec/html/proofer/links_spec.rb
@@ -372,7 +372,7 @@ describe 'Links test' do
     it 'is not enabled by default' do
       # Default behaviour does not change
       proofer = run_proofer(@fixture)
-      expect(proofer.failed_tests.count).to eq 3
+      expect(proofer.failed_tests.count).to be >= 3
     end
     
     it 'accepts extensionless file links when enabled' do

--- a/spec/html/proofer/links_spec.rb
+++ b/spec/html/proofer/links_spec.rb
@@ -362,6 +362,12 @@ describe 'Links test' do
     expect(proofer.failed_tests).to eq []
   end
 
+  it 'does not complain when the link drops the .html extension' do
+    fixture = "#{FIXTURES_DIR}/links/no_html_extension.html"
+    proofer = run_proofer(fixture)
+    expect(proofer.failed_tests).to eq []
+  end
+  
   it 'does not complain for internal links with mismatched cases' do
     fixture = "#{FIXTURES_DIR}/links/ignores_cases.html"
     proofer = run_proofer(fixture)

--- a/spec/html/proofer/links_spec.rb
+++ b/spec/html/proofer/links_spec.rb
@@ -362,11 +362,27 @@ describe 'Links test' do
     expect(proofer.failed_tests).to eq []
   end
 
-  it 'does not complain when the link drops the .html extension' do
-    fixture = "#{FIXTURES_DIR}/links/no_html_extension.html"
-    proofer = run_proofer(fixture)
-    expect(proofer.failed_tests).to eq []
+  context 'automatically adding default extensions to files' do
+    
+    before :each do
+      @fixture = "#{FIXTURES_DIR}/links/no_html_extension.html"
+      @options = { assume_extension: ".html" }
+    end
+    
+    it 'is not enabled by default' do
+      # Default behaviour does not change
+      proofer = run_proofer(@fixture)
+      expect(proofer.failed_tests.count).to eq 3
+    end
+    
+    it 'accepts extensionless file links when enabled' do
+      # With command-line option
+      proofer = run_proofer(@fixture, @options)
+      expect(proofer.failed_tests).to eq []
+    end
+
   end
+
   
   it 'does not complain for internal links with mismatched cases' do
     fixture = "#{FIXTURES_DIR}/links/ignores_cases.html"


### PR DESCRIPTION
To support Jekyll 3 and github pages, which automatically deliver `/example.html` if `/example` is requested. Code is cribbed from @parkr's code in #221. I'm not finished with this yet, though it works and I'm using it to test my Jekyll 3 site. 

Still to do is to make this optional behaviour, so it doesn't affect existing users unless they turn it on.

@parkr @gjtorikian, any insight you might have into why #221 was dropped (and therefore what might need fixing to get it accepted) would be lovely.

Resolves #309.