### PR TITLE
htmlproofer should set status codes to ints

### DIFF
--- a/bin/htmlproofer
+++ b/bin/htmlproofer
@@ -51,6 +51,8 @@ Mercenary.program(:htmlproofer) do |p|
       end
       options[option.config_key.to_sym] = opts[option.config_key]
     end
+    
+    options[:http_status_ignore] = options[:http_status_ignore].map(&:to_i)
 
     # some minor manipulation of a special option
     unless opts['url_swap'].nil?

--- a/bin/htmlproofer
+++ b/bin/htmlproofer
@@ -51,8 +51,6 @@ Mercenary.program(:htmlproofer) do |p|
       end
       options[option.config_key.to_sym] = opts[option.config_key]
     end
-    
-    options[:http_status_ignore] = options[:http_status_ignore].map(&:to_i)
 
     # some minor manipulation of a special option
     unless opts['url_swap'].nil?
@@ -73,6 +71,8 @@ Mercenary.program(:htmlproofer) do |p|
 
     options[:cache] = {}
     options[:cache][:timeframe] = opts['timeframe'] unless opts['timeframe'].nil?
+    
+    options[:http_status_ignore] = Array(options[:http_status_ignore]).map(&:to_i)
 
     paths = path.split(',')
     if opts['as_links']


### PR DESCRIPTION
`ignored_status_codes.include? 429` will be false if `ignored_status_codes = ["429"]`