### PR TITLE
Added escape sequences for --url-swap

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,9 @@ Pass in options through the command-line, like this:
 htmlproofer ./out --url-swap wow:cow,mow:doh --extension .html.erb --url-ignore www.github.com
 ```
 
-Note: since `url_swap` is a bit special, you'll pass in a pair of `RegEx:String` values.
-`htmlproofer` will figure out what you mean.
+Note: since `url_swap` is a bit special, you'll pass in a pair of `RegEx:String`
+values. The escape sequences `\:` and `\\` should be used to produce literal
+`:`s and `\`s. `htmlproofer` will figure out what you mean.
 
 ### Using with Jekyll
 

--- a/bin/htmlproofer
+++ b/bin/htmlproofer
@@ -37,7 +37,7 @@ Mercenary.program(:htmlproofer) do |p|
   p.option 'only_4xx', '--only-4xx', 'Only reports errors for links that fall within the 4xx status code range'
   p.option 'timeframe', '--timeframe <time>', String, 'A string representing the caching timeframe.'
   p.option 'url_ignore', '--url-ignore link1,[link2,...]', Array, 'A comma-separated list of Strings or RegExps containing URLs that are safe to ignore. It affects all HTML attributes. Note that non-HTTP(S) URIs are always ignored'
-  p.option 'url_swap', '--url-swap re:string,[re:string,...]', Array, 'A comma-separated list containing key-value pairs of `RegExp => String`. It transforms URLs that match `RegExp` into `String` via `gsub`.'
+  p.option 'url_swap', '--url-swap re:string,[re:string,...]', Array, 'A comma-separated list containing key-value pairs of `RegExp => String`. It transforms URLs that match `RegExp` into `String` via `gsub`. The escape sequences `\\:` and `\\\\` should be used to produce literal `:`s and `\\`s.'
 
   p.action do |args, opts|
     args = ['.'] if args.empty?
@@ -57,8 +57,37 @@ Mercenary.program(:htmlproofer) do |p|
     unless opts['url_swap'].nil?
       options[:url_swap] = {}
       opts['url_swap'].each do |s|
-        pair = s.split(':', 2)
-        options[:url_swap][Regexp.new(pair[0])] = pair[1]
+        re = string = ''
+
+        is_re = true
+        is_escaped = false
+
+        s.each_char do |c|
+          value = c
+
+          case c
+          when '\\'
+            value = '' unless is_escaped
+            is_escaped = !is_escaped
+          when ':'
+            if is_escaped
+              is_escaped = false
+            else
+              value = ''
+              is_re = false
+            end
+          else
+            is_escaped = false
+          end
+
+          if is_re
+            re += value
+          else
+            string += value
+          end
+        end
+
+        options[:url_swap][Regexp.new(re)] = string
       end
     end
 

--- a/spec/html-proofer/command_spec.rb
+++ b/spec/html-proofer/command_spec.rb
@@ -58,7 +58,7 @@ describe 'Command test' do
 
   it 'works with url-swap' do
     translatedLink = "#{FIXTURES_DIR}/links/linkTranslatedViaHrefSwap.html"
-    output = make_bin('--url-swap "\A/articles/([\w-]+):\1.html"', translatedLink)
+    output = make_bin('--url-swap "\\\\\\\\A/articles/([\\\\\\\\w-]+):\\\\\\\\1.html"', translatedLink)
     expect(output).to match('successfully')
   end
 


### PR DESCRIPTION
Fixed #293 by adding `\\` and `\:` as escape sequences for the
`--url-swap` flag. This allows command line users the same
expressiveness as Ruby users.