### PR TITLE
Show return message for status code 0

### DIFF
--- a/lib/html-proofer/url_validator.rb
+++ b/lib/html-proofer/url_validator.rb
@@ -150,7 +150,7 @@ module HTMLProofer
       elsif response.timed_out?
         handle_timeout(href, filenames, response_code)
       elsif response_code == 0
-        handle_failure(href, filenames, response_code)
+        handle_failure(href, filenames, response_code, response.return_message)
       elsif method == :head
         queue_request(:get, href, filenames)
       else
@@ -192,8 +192,8 @@ module HTMLProofer
       add_external_issue(filenames, msg, response_code)
     end
 
-    def handle_failure(href, filenames, response_code)
-      msg = "External link #{href} failed: response code #{response_code} means something's wrong"
+    def handle_failure(href, filenames, response_code, return_message)
+      msg = "External link #{href} failed: response code #{response_code} means something's wrong; return message says '#{return_message}'"
       @cache.add(href, filenames, 0, msg)
       return if @options[:only_4xx]
       add_external_issue(filenames, msg, response_code)

--- a/spec/html-proofer/cache_spec.rb
+++ b/spec/html-proofer/cache_spec.rb
@@ -84,7 +84,7 @@ describe 'Cache test' do
 
     expect_any_instance_of(HTMLProofer::Cache).to receive(:write)
     # we expect the same link to be readded...
-    expect_any_instance_of(HTMLProofer::Cache).to receive(:add).with('www.foofoofoo.biz', nil, 0, 'External link www.foofoofoo.biz failed: response code 0 means something\'s wrong')
+    expect_any_instance_of(HTMLProofer::Cache).to receive(:add).with('www.foofoofoo.biz', nil, 0, 'External link www.foofoofoo.biz failed: response code 0 means something\'s wrong; return message says \'\'')
 
     # ...even though we are within the 30d time frame,
     # because it's a failure


### PR DESCRIPTION
Message can be populated and useful to know. I've only seen in execution environment I can't control (CI) and [want](https://github.com/github/choosealicense.com/pull/374) to see additional feedback. https://github.com/gjtorikian/html-proofer/issues/299#issuecomment-194754495 shows someone else's example of this. But apparently (#321) others see status code 0 when run locally and wonder what's wrong.

Unresolvable host is one status code 0 message that I can produce easily. I haven't added a test for this as an expected message because I haven't figured out how to have test output not recorded, or recorded with message -- 2nd time new test (not in this PR) is run without deleting recording, there is no message, so test fails.