### PR TITLE
Properly ignore alt without ignoring image

### DIFF
--- a/lib/html-proofer/check/images.rb
+++ b/lib/html-proofer/check/images.rb
@@ -37,7 +37,7 @@ class ImageCheck < ::HTMLProofer::Check
         end
       end
 
-      if @img.alt.nil? || (empty_alt_tag? && !@img.ignore_empty_alt?)
+      if !@img.ignore_alt? && (@img.alt.nil? || (empty_alt_tag? && !@img.ignore_empty_alt?))
         add_issue("image #{@img.url} does not have an alt attribute", line: line)
       end
     end

--- a/lib/html-proofer/element.rb
+++ b/lib/html-proofer/element.rb
@@ -25,6 +25,7 @@ module HTMLProofer
       # fix up missing protocols
       @href.insert 0, 'http:' if @href =~ %r{^//}
       @src.insert 0, 'http:' if @src =~ %r{^//}
+      @srcset.insert 0, 'http:' if @srcset =~ %r{^//}
     end
 
     def url
@@ -76,9 +77,9 @@ module HTMLProofer
 
       # ignore user defined URLs
       return true if ignores_pattern_check(@check.options[:url_ignore])
+    end
 
-      # ignore user defined alts
-      return false unless 'ImageCheck' == @type
+    def ignore_alt?
       return true if ignores_pattern_check(@check.options[:alt_ignore])
     end
 

--- a/spec/html-proofer/fixtures/vcr_cassettes/images/ignorableAltViaOptions_html_alt_ignore_/wikimedia/_gpl_png_log_level_error_type_file_.yml
+++ b/spec/html-proofer/fixtures/vcr_cassettes/images/ignorableAltViaOptions_html_alt_ignore_/wikimedia/_gpl_png_log_level_error_type_file_.yml
@@ -1,0 +1,67 @@
+---
+http_interactions:
+- request:
+    method: head
+    uri: http://upload.wikimedia.org/wikipedia/en/thumb/2/22/Heckert_GNU_white.svg/256px-Heckert_GNU_white.svg.png
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/3.0.5; +https://github.com/gjtorikian/html-proofer)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 15 Apr 2016 16:26:21 GMT
+      Content-Type:
+      - image/png
+      Content-Length:
+      - '27063'
+      Connection:
+      - keep-alive
+      X-Object-Meta-Sha1base36:
+      - mm95ioarmv2n0yvfyg4czr9qxzhf44v
+      Last-Modified:
+      - Tue, 05 Apr 2016 01:46:52 GMT
+      Etag:
+      - b02df8baa52837645bd58a219be4d9dc
+      X-Timestamp:
+      - '1459820811.68493'
+      X-Trans-Id:
+      - tx88a29ce4c42b4820b2cfb-005710ecf3
+      X-Varnish:
+      - 2949978056 2911261333, 1553418594 1551989283
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      Accept-Ranges:
+      - bytes
+      Age:
+      - '10555'
+      X-Cache:
+      - cp2008 hit(7), cp2014 frontend hit(8)
+      Strict-Transport-Security:
+      - max-age=31536000
+      Set-Cookie:
+      - WMF-Last-Access=15-Apr-2016;Path=/;HttpOnly;Expires=Tue, 17 May 2016 12:00:00
+        GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-IP:
+      - 98.218.216.32
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Age, Date, Content-Length, Content-Range, X-Content-Duration, X-Cache, X-Varnish
+      Timing-Allow-Origin:
+      - "*"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://upload.wikimedia.org/wikipedia/en/thumb/2/22/Heckert_GNU_white.svg/256px-Heckert_GNU_white.svg.png
+  recorded_at: Fri, 15 Apr 2016 16:26:21 GMT
+recorded_with: VCR 2.9.3

--- a/spec/html-proofer/fixtures/vcr_cassettes/images/srcSetIgnorable_html_alt_ignore_/wikimedia/_gpl_png_log_level_error_type_file_.yml
+++ b/spec/html-proofer/fixtures/vcr_cassettes/images/srcSetIgnorable_html_alt_ignore_/wikimedia/_gpl_png_log_level_error_type_file_.yml
@@ -1,0 +1,67 @@
+---
+http_interactions:
+- request:
+    method: head
+    uri: http://upload.wikimedia.org/wikipedia/en/thumb/2/22/Heckert_GNU_white.svg/256px-Heckert_GNU_white.svg.png
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/3.0.5; +https://github.com/gjtorikian/html-proofer)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 15 Apr 2016 16:26:21 GMT
+      Content-Type:
+      - image/png
+      Content-Length:
+      - '27063'
+      Connection:
+      - keep-alive
+      X-Object-Meta-Sha1base36:
+      - mm95ioarmv2n0yvfyg4czr9qxzhf44v
+      Last-Modified:
+      - Tue, 05 Apr 2016 01:46:52 GMT
+      Etag:
+      - b02df8baa52837645bd58a219be4d9dc
+      X-Timestamp:
+      - '1459820811.68493'
+      X-Trans-Id:
+      - tx88a29ce4c42b4820b2cfb-005710ecf3
+      X-Varnish:
+      - 2949978056 2911261333, 1553416798 1551989283
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      Accept-Ranges:
+      - bytes
+      Age:
+      - '10554'
+      X-Cache:
+      - cp2008 hit(7), cp2014 frontend hit(7)
+      Strict-Transport-Security:
+      - max-age=31536000
+      Set-Cookie:
+      - WMF-Last-Access=15-Apr-2016;Path=/;HttpOnly;Expires=Tue, 17 May 2016 12:00:00
+        GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-IP:
+      - 98.218.216.32
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Age, Date, Content-Length, Content-Range, X-Content-Duration, X-Cache, X-Varnish
+      Timing-Allow-Origin:
+      - "*"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://upload.wikimedia.org/wikipedia/en/thumb/2/22/Heckert_GNU_white.svg/256px-Heckert_GNU_white.svg.png
+  recorded_at: Fri, 15 Apr 2016 16:26:21 GMT
+recorded_with: VCR 2.9.3

--- a/spec/html-proofer/images_spec.rb
+++ b/spec/html-proofer/images_spec.rb
@@ -38,6 +38,12 @@ describe 'Images test' do
     expect(proofer.failed_tests.first).to match(/failed: response code 0/)
   end
 
+  it 'fails for missing internal images even when alt_ignore is set' do
+    internalImageFilepath = "#{FIXTURES_DIR}/images/missingImageInternal.html"
+    proofer = run_proofer(internalImageFilepath, :file, {:alt_ignore => [/.*/]})
+    expect(proofer.failed_tests.first).to match(/doesnotexist.png does not exist/)
+  end
+
   it 'fails for missing internal images' do
     internalImageFilepath = "#{FIXTURES_DIR}/images/missingImageInternal.html"
     proofer = run_proofer(internalImageFilepath, :file)


### PR DESCRIPTION
* alt_ignore for an image does not ignore the whole image now. If it is missing, it will be reported.
* Also, this unearthed another issue, where srcset was not properly 'fixed' by prefixing it with http://.

Just so it is clear, without this change, any image that was alt_ignored-d, was ignored [here](https://github.com/gjtorikian/html-proofer/blob/0669699e8eb575456db97cfe6246591e37718e25/lib/html-proofer/check/images.rb#L21) in the checking process, and so, if the image it referred to is missing, the issue wouldn't be added to the final result.