### PR TITLE
Use regex for colon escape

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ htmlproofer ./out --url-swap wow:cow,mow:doh --extension .html.erb --url-ignore 
 ```
 
 Note: since `url_swap` is a bit special, you'll pass in a pair of `RegEx:String`
-values. The escape sequences `\:` and `\\` should be used to produce literal
-`:`s and `\`s. `htmlproofer` will figure out what you mean.
+values. The escape sequences `\:` should be used to produce literal
+`:`s `htmlproofer` will figure out what you mean.
 
 ### Using with Jekyll
 

--- a/bin/htmlproofer
+++ b/bin/htmlproofer
@@ -38,7 +38,7 @@ Mercenary.program(:htmlproofer) do |p|
   p.option 'only_4xx', '--only-4xx', 'Only reports errors for links that fall within the 4xx status code range'
   p.option 'timeframe', '--timeframe <time>', String, 'A string representing the caching timeframe.'
   p.option 'url_ignore', '--url-ignore link1,[link2,...]', Array, 'A comma-separated list of Strings or RegExps containing URLs that are safe to ignore. It affects all HTML attributes. Note that non-HTTP(S) URIs are always ignored'
-  p.option 'url_swap', '--url-swap re:string,[re:string,...]', Array, 'A comma-separated list containing key-value pairs of `RegExp => String`. It transforms URLs that match `RegExp` into `String` via `gsub`. The escape sequences `\\:` and `\\\\` should be used to produce literal `:`s and `\\`s.'
+  p.option 'url_swap', '--url-swap re:string,[re:string,...]', Array, 'A comma-separated list containing key-value pairs of `RegExp => String`. It transforms URLs that match `RegExp` into `String` via `gsub`. The escape sequences `\\:` should be used to produce literal `:`s.'
 
   p.action do |args, opts|
     args = ['.'] if args.empty?
@@ -58,36 +58,10 @@ Mercenary.program(:htmlproofer) do |p|
     unless opts['url_swap'].nil?
       options[:url_swap] = {}
       opts['url_swap'].each do |s|
-        re = string = ''
+        splt = s.split(/(?<!\\):/,2)
 
-        is_re = true
-        is_escaped = false
-
-        s.each_char do |c|
-          value = c
-
-          case c
-          when '\\'
-            value = '' unless is_escaped
-            is_escaped = !is_escaped
-          when ':'
-            if is_escaped
-              is_escaped = false
-            else
-              value = ''
-              is_re = false
-            end
-          else
-            is_escaped = false
-          end
-
-          if is_re
-            re += value
-          else
-            string += value
-          end
-        end
-
+        re = splt[0].gsub(/\\:/, ':')
+        string = splt[1].gsub(/\\:/, ':')
         options[:url_swap][Regexp.new(re)] = string
       end
     end

--- a/spec/html-proofer/command_spec.rb
+++ b/spec/html-proofer/command_spec.rb
@@ -58,7 +58,13 @@ describe 'Command test' do
 
   it 'works with url-swap' do
     translatedLink = "#{FIXTURES_DIR}/links/linkTranslatedViaHrefSwap.html"
-    output = make_bin('--url-swap "\\\\\\\\A/articles/([\\\\\\\\w-]+):\\\\\\\\1.html"', translatedLink)
+    output = make_bin('--url-swap "\A/articles/([\w-]+):\1.html"', translatedLink)
+    expect(output).to match('successfully')
+  end
+  
+  it 'works with url-swap and colon' do
+    translatedLink = "#{FIXTURES_DIR}/links/linkTranslatedViaHrefSwap2.html"
+    output = make_bin('--url-swap "http\://www.example.com:"', translatedLink)
     expect(output).to match('successfully')
   end
 

--- a/spec/html-proofer/fixtures/links/linkTranslatedViaHrefSwap2.html
+++ b/spec/html-proofer/fixtures/links/linkTranslatedViaHrefSwap2.html
@@ -1,0 +1,9 @@
+<html>
+
+<body>
+
+<a href="http://www.example.com/linkToFolder.html">A real file, but the href should change!</a>
+
+</body>
+
+</html>


### PR DESCRIPTION
This replaces the detection of escaped colons to a regex, thereby voiding the need to escape backslashes.
Add test and fixture for an escaped colon.