### PR TITLE
Add --internal-domains option

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ The `HTMLProofer` constructor takes an optional hash of additional options:
 | `external_only` | Only checks problems with external references. | `false`
 | `file_ignore` | An array of Strings or RegExps containing file paths that are safe to ignore. | `[]` |
 | `http_status_ignore` | An array of numbers representing status codes to ignore. | `[]`
+| `internal-domains`| An array of Strings containing URLs that will be treated as internal | `[]` |
 | `log_level` | Sets the logging level, as determined by [Yell](https://github.com/rudionrails/yell). | `:info`
 | `only_4xx` | Only reports errors for links that fall within the 4xx status code range. | `false` |
 | `url_ignore` | An array of Strings or RegExps containing URLs that are safe to ignore. It affects all HTML attributes. Note that non-HTTP(S) URIs are always ignored. | `[]` |

--- a/bin/htmlproofer
+++ b/bin/htmlproofer
@@ -39,6 +39,7 @@ Mercenary.program(:htmlproofer) do |p|
   p.option 'timeframe', '--timeframe <time>', String, 'A string representing the caching timeframe.'
   p.option 'url_ignore', '--url-ignore link1,[link2,...]', Array, 'A comma-separated list of Strings or RegExps containing URLs that are safe to ignore. It affects all HTML attributes. Note that non-HTTP(S) URIs are always ignored'
   p.option 'url_swap', '--url-swap re:string,[re:string,...]', Array, 'A comma-separated list containing key-value pairs of `RegExp => String`. It transforms URLs that match `RegExp` into `String` via `gsub`. The escape sequences `\\:` and `\\\\` should be used to produce literal `:`s and `\\`s.'
+  p.option 'internal_domains', '--internal-domains domain1,[domain2,...]', Array, 'A comma-separated list of Strings containing URLs that will be treated as internal urls. It removes the url'
 
   p.action do |args, opts|
     args = ['.'] if args.empty?

--- a/lib/html-proofer/runner.rb
+++ b/lib/html-proofer/runner.rb
@@ -7,6 +7,18 @@ module HTMLProofer
     def initialize(src, opts = {})
       @src = src
 
+      # Add swap patterns for internal domains
+      unless opts[:internal_domains].nil?
+        if opts[:url_swap].nil?
+          opts[:url_swap] = {}
+        end
+        opts[:internal_domains].each do |dom|
+          opts[:url_swap][Regexp.new("^http://#{dom}")] = ""
+          opts[:url_swap][Regexp.new("^https://#{dom}")] = ""
+          opts[:url_swap][Regexp.new("^//#{dom}")] = ""
+        end
+      end
+
       @options = HTMLProofer::Configuration::PROOFER_DEFAULTS.merge(opts)
 
       @options[:typhoeus] = HTMLProofer::Configuration::TYPHOEUS_DEFAULTS.merge(opts[:typhoeus] || {})

--- a/spec/html-proofer/command_spec.rb
+++ b/spec/html-proofer/command_spec.rb
@@ -50,6 +50,12 @@ describe 'Command test' do
     expect(output).to match('successfully')
   end
 
+  it 'works with internal-domains' do
+    translatedLink = "#{FIXTURES_DIR}/links/linkTranslatedInternalDomains.html"
+    output = make_bin('--internal-domains www.example.com,example.com', translatedLink)
+    expect(output).to match('successfully')
+  end
+
   it 'works with url-ignore' do
     ignorableLinks = "#{FIXTURES_DIR}/links/ignorableLinksViaOptions.html"
     output = make_bin('--url-ignore /^http:\/\//,/sdadsad/,../whaadadt.html', ignorableLinks)

--- a/spec/html-proofer/fixtures/links/linkTranslatedInternalDomains.html
+++ b/spec/html-proofer/fixtures/links/linkTranslatedInternalDomains.html
@@ -1,0 +1,11 @@
+<html>
+
+<body>
+
+  <a href="http://www.example.com/linkToFolder.html">A real file, but the href should change!</a>
+  <a href="https://example.com/linkToFolder.html">A real file, but the href should change!</a>
+  <img alt="internal domain test" src="//www.example.com/gpl.png">
+
+</body>
+
+</html>

--- a/spec/html-proofer/links_spec.rb
+++ b/spec/html-proofer/links_spec.rb
@@ -467,4 +467,11 @@ describe 'Links test' do
     proofer = run_proofer(missing_href, :file)
     expect(proofer.failed_tests.length).to eq 1
   end
+
+  it 'translates links via url_swap' do
+    translatedLink = "#{FIXTURES_DIR}/links/linkTranslatedInternalDomains.html"
+    proofer = run_proofer(translatedLink, :file, { :internal_domains => ['www.example.com', 'example.com'] })
+    expect(proofer.failed_tests).to eq []
+  end
+
 end


### PR DESCRIPTION
Adds an option to treat certain domains as internal.
Any domains specified will be removed from URLs via the url_swap feature.

Closes #349 