### PR TITLE
Add support for `base` element

### DIFF
--- a/lib/html-proofer/check.rb
+++ b/lib/html-proofer/check.rb
@@ -1,7 +1,7 @@
 module HTMLProofer
   # Mostly handles issue management and collecting of external URLs.
   class Check
-    attr_reader :node, :element, :src, :path, :options, :issues, :external_urls
+    attr_reader :node, :html, :element, :src, :path, :options, :issues, :external_urls
 
     def initialize(src, path, html, options)
       @src    = src

--- a/spec/html-proofer/element_spec.rb
+++ b/spec/html-proofer/element_spec.rb
@@ -7,47 +7,54 @@ describe HTMLProofer::Element do
 
   describe '#initialize' do
     it 'accepts the xmlns attribute' do
-      nokogiri = Nokogiri::HTML '<a xmlns:cc="http://creativecommons.org/ns#">Creative Commons</a>'
-      checkable = HTMLProofer::Element.new nokogiri.css('a').first, @check
+      nokogiri = Nokogiri::HTML('<a xmlns:cc="http://creativecommons.org/ns#">Creative Commons</a>')
+      checkable = HTMLProofer::Element.new(nokogiri.css('a').first, @check)
       expect(checkable.instance_variable_get(:@xmlns_cc)).to eq 'http://creativecommons.org/ns#'
     end
+
     it 'assignes the text node' do
-      nokogiri = Nokogiri::HTML '<p>One'
-      checkable = HTMLProofer::Element.new nokogiri.css('p').first, @check
+      nokogiri = Nokogiri::HTML('<p>One')
+      checkable = HTMLProofer::Element.new(nokogiri.css('p').first, @check)
       expect(checkable.instance_variable_get(:@text)).to eq 'One'
     end
+
     it 'accepts the content attribute' do
-      nokogiri = Nokogiri::HTML '<meta name="twitter:card" content="summary">'
-      checkable = HTMLProofer::Element.new nokogiri.css('meta').first, nil
+      nokogiri = Nokogiri::HTML('<meta name="twitter:card" content="summary">')
+      checkable = HTMLProofer::Element.new(nokogiri.css('meta').first, @check)
       expect(checkable.instance_variable_get(:@content)).to eq 'summary'
     end
   end
+
   describe '#ignores_pattern_check' do
     it 'works for regex patterns' do
-      nokogiri = Nokogiri::HTML '<script src=/assets/main.js></script>'
-      checkable = HTMLProofer::Element.new nokogiri.css('script').first, @check
+      nokogiri = Nokogiri::HTML('<script src=/assets/main.js></script>')
+      checkable = HTMLProofer::Element.new(nokogiri.css('script').first, @check)
       expect(checkable.ignores_pattern_check([/\/assets\/.*(js|css|png|svg)/])).to eq true
     end
+
     it 'works for string patterns' do
-      nokogiri = Nokogiri::HTML '<script src=/assets/main.js></script>'
-      checkable = HTMLProofer::Element.new nokogiri.css('script').first, @check
+      nokogiri = Nokogiri::HTML('<script src=/assets/main.js></script>')
+      checkable = HTMLProofer::Element.new(nokogiri.css('script').first, @check)
       expect(checkable.ignores_pattern_check(['/assets/main.js'])).to eq true
     end
   end
+
   describe '#url' do
     it 'works for src attributes' do
-      nokogiri = Nokogiri::HTML '<img src=image.png />'
-      checkable = HTMLProofer::Element.new nokogiri.css('img').first, @check
+      nokogiri = Nokogiri::HTML('<img src=image.png />')
+      checkable = HTMLProofer::Element.new(nokogiri.css('img').first, @check)
       expect(checkable.url).to eq 'image.png'
     end
   end
+
   describe '#ignore' do
     it 'works for twitter cards' do
-      nokogiri = Nokogiri::HTML '<meta name="twitter:url" data-proofer-ignore content="http://example.com/soon-to-be-published-url">'
-      checkable = HTMLProofer::Element.new nokogiri.css('meta').first, @check
+      nokogiri = Nokogiri::HTML('<meta name="twitter:url" data-proofer-ignore content="http://example.com/soon-to-be-published-url">')
+      checkable = HTMLProofer::Element.new(nokogiri.css('meta').first, @check)
       expect(checkable.ignore?).to eq true
     end
   end
+
   describe 'ivar setting' do
     it 'does not explode if given a bad attribute' do
       broken_attribute = "#{FIXTURES_DIR}/html/invalid_attribute.html"

--- a/spec/html-proofer/fixtures/images/relativeWithBase.html.html
+++ b/spec/html-proofer/fixtures/images/relativeWithBase.html.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <base href="/links/">
+  </head>
+  <body>
+    <img alt="relative to base" src="gpl.png"/>
+    <img alt="subdirectory relative to base" src="folder/assets/barrel.png"/>
+    <img alt="relative to base sibling" src="../images/gpl.png"/>
+    <img alt="relative to root" src="/images/gpl.png"/>
+  </body>
+</html>

--- a/spec/html-proofer/fixtures/links/relativeLinksWithBase.html
+++ b/spec/html-proofer/fixtures/links/relativeLinksWithBase.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <base href="folder/">
+  </head>
+  <body>
+    <a href="/anchors_in_pre.html">Relative to root</a>
+    <a href="anchorLink.html">Relative to base</a>
+    <a href="../relativeLinks.html">Back relative to base</a>
+  </body>
+</html>

--- a/spec/html-proofer/images_spec.rb
+++ b/spec/html-proofer/images_spec.rb
@@ -180,4 +180,10 @@ describe 'Images test' do
     proofer = run_proofer(http, :file, { :check_img_http => true })
     expect(proofer.failed_tests.first).to match(/uses the http scheme/)
   end
+
+  it 'properly checks relative images with base' do
+    relativeImages = "#{FIXTURES_DIR}/images/relativeWithBase.html"
+    proofer = run_proofer(relativeImages, :file)
+    expect(proofer.failed_tests).to eq []
+  end
 end

--- a/spec/html-proofer/links_spec.rb
+++ b/spec/html-proofer/links_spec.rb
@@ -474,4 +474,9 @@ describe 'Links test' do
     expect(proofer.failed_tests).to eq []
   end
 
+  it 'passes for relative links with a base' do
+    relativeLinks = "#{FIXTURES_DIR}/links/relativeLinksWithBase.html"
+    proofer = run_proofer(relativeLinks, :file)
+    expect(proofer.failed_tests).to eq []
+  end
 end


### PR DESCRIPTION
From [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base)

> The **HTML `<base>` element** specifies the base URL to use for all relative URLs contained within a document.

Successor to https://github.com/gjtorikian/html-proofer/pull/265, closes #166.

/cc @bkeepers