### PR TITLE
test url maybe once obtained 406, now 404

### DIFF
--- a/spec/html-proofer/opengraph_spec.rb
+++ b/spec/html-proofer/opengraph_spec.rb
@@ -46,7 +46,7 @@ describe 'Open Graph test' do
   it 'fails for missing external image' do
     url_valid = "#{FIXTURES_DIR}/opengraph/image-broken.html"
     proofer = run_proofer(url_valid, :file, { :check_opengraph => true })
-    expect(proofer.failed_tests.first).to match(/failed: 406/)
+    expect(proofer.failed_tests.first).to match(/failed: 404/)
   end
 
   it 'fails for missing internal images' do


### PR DESCRIPTION
Or maybe a [fluke](https://github.com/gjtorikian/html-proofer/pull/372#issuecomment-273313963)? Sending this in case not, did before noticing linked comment. Ignore if useless. :smile: