### PR TITLE
Skip DNS prefetch links for now

### DIFF
--- a/html-proofer.gemspec
+++ b/html-proofer.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'redcarpet'
   gem.add_development_dependency 'rspec', '~> 3.1'
   gem.add_development_dependency 'rake'
+  gem.add_development_dependency 'pry', '~> 0.10.0'
   gem.add_development_dependency 'awesome_print'
   gem.add_development_dependency 'vcr', '~> 2.9'
   gem.add_development_dependency 'timecop', '~> 0.8'

--- a/lib/html-proofer.rb
+++ b/lib/html-proofer.rb
@@ -14,6 +14,7 @@ require 'fileutils'
 
 begin
   require 'awesome_print'
+  require 'pry'
 rescue LoadError; end
 
 module HTMLProofer

--- a/lib/html-proofer/check/links.rb
+++ b/lib/html-proofer/check/links.rb
@@ -38,8 +38,11 @@ class LinkCheck < ::HTMLProofer::Check
 
       # intentionally here because we still want valid? & missing_href? to execute
       next if @link.non_http_remote?
-      # does the file even exist?
+
       if !@link.internal? && @link.remote?
+        # we need to skip these for now; although the domain main be valid,
+        # curl/Typheous inaccurately return 404s for some links. cc https://git.io/vyCFx
+        next if @link.try(:rel) == 'dns-prefetch'
         add_to_external_urls(@link.href)
         next
       elsif !@link.internal? && !@link.exists?

--- a/spec/html-proofer/links_spec.rb
+++ b/spec/html-proofer/links_spec.rb
@@ -394,9 +394,7 @@ describe 'Links test' do
       proofer = run_proofer(@fixture, :file, @options)
       expect(proofer.failed_tests).to eq []
     end
-
   end
-
 
   it 'does not complain for internal links with mismatched cases' do
     fixture = "#{FIXTURES_DIR}/links/ignores_cases.html"
@@ -483,6 +481,12 @@ describe 'Links test' do
   it 'passes for relative links with a base' do
     relativeLinks = "#{FIXTURES_DIR}/links/relativeLinksWithBase.html"
     proofer = run_proofer(relativeLinks, :file)
+    expect(proofer.failed_tests).to eq []
+  end
+
+  it 'does not bomb on dns-prefetch' do
+    prefetch = "#{FIXTURES_DIR}/links/dns-prefetch.html"
+    proofer = run_proofer(prefetch, :file)
     expect(proofer.failed_tests).to eq []
   end
 end


### PR DESCRIPTION
Closes https://github.com/gjtorikian/html-proofer/issues/389.

Unfortunately, there's no way to assert if a domain is valid or not when it's marked up as `dns-prefetch`. The attribute provides numerous benefits to the user, so I don't want these to mark as false positive.

It is entirely possible for someone to provide a bogus URL here. But, since this is largely confined to how a browser behaves and is not related to a user experience, I am fine trading correctness for performance in this case.