### PR TITLE
Ensure lack of slash in error messages

### DIFF
--- a/lib/html-proofer/url_validator.rb
+++ b/lib/html-proofer/url_validator.rb
@@ -156,7 +156,7 @@ module HTMLProofer
       else
         return if @options[:only_4xx] && !response_code.between?(400, 499)
         # Received a non-successful http response.
-        msg = "External link #{href} failed: #{response_code} #{response.return_message}"
+        msg = "External link #{href.chomp('/')} failed: #{response_code} #{response.return_message}"
         add_external_issue(filenames, msg, response_code)
         @cache.add(href, filenames, response_code, msg)
       end
@@ -179,21 +179,21 @@ module HTMLProofer
 
       return unless body_doc.xpath(xpath).empty?
 
-      msg = "External link #{href} failed: #{effective_url} exists, but the hash '#{hash}' does not"
+      msg = "External link #{href.chomp('/')} failed: #{effective_url} exists, but the hash '#{hash}' does not"
       add_external_issue(filenames, msg, response.code)
       @cache.add(href, filenames, response.code, msg)
       true
     end
 
     def handle_timeout(href, filenames, response_code)
-      msg = "External link #{href} failed: got a time out (response code #{response_code})"
+      msg = "External link #{href.chomp('/')} failed: got a time out (response code #{response_code})"
       @cache.add(href, filenames, 0, msg)
       return if @options[:only_4xx]
       add_external_issue(filenames, msg, response_code)
     end
 
     def handle_failure(href, filenames, response_code, return_message)
-      msg = "External link #{href} failed: response code #{response_code} means something's wrong.
+      msg = "External link #{href.chomp('/')} failed: response code #{response_code} means something's wrong.
              It's possible libcurl couldn't connect to the server or perhaps the request timed out.
              Sometimes, making too many requests at once also breaks things.
              Either way, the return message (if any) from the server is: #{return_message}"

--- a/spec/html-proofer/links_spec.rb
+++ b/spec/html-proofer/links_spec.rb
@@ -42,7 +42,10 @@ describe 'Links test' do
   it 'fails for broken external links' do
     brokenLinkExternalFilepath = "#{FIXTURES_DIR}/links/brokenLinkExternal.html"
     proofer = run_proofer(brokenLinkExternalFilepath, :file)
-    expect(proofer.failed_tests.first).to match(/failed: response code 0/)
+    failure = proofer.failed_tests.first
+    expect(failure).to match(/failed: response code 0/)
+    # ensure lack of slash in error message
+    expect(failure).to match(%r{External link http://www.asdo3irj395295jsingrkrg4.com failed:})
   end
 
   it 'passes for different filename without option' do


### PR DESCRIPTION
Typheous unfortunately occasionally adds an extra slash when it attempts
to check external URLs. This change at least removes that slash from
the URL to make future grepping easier, if not 100% accurate.

Closes https://github.com/gjtorikian/html-proofer/issues/378.