### PR TITLE
Make cache storage directory configurable

### DIFF
--- a/bin/htmlproofer
+++ b/bin/htmlproofer
@@ -42,6 +42,7 @@ Mercenary.program(:htmlproofer) do |p|
   p.option 'url_ignore', '--url-ignore link1,[link2,...]', Array, 'A comma-separated list of Strings or RegExps containing URLs that are safe to ignore. It affects all HTML attributes. Note that non-HTTP(S) URIs are always ignored'
   p.option 'url_swap', '--url-swap re:string,[re:string,...]', Array, 'A comma-separated list containing key-value pairs of `RegExp => String`. It transforms URLs that match `RegExp` into `String` via `gsub`. The escape sequences `\\:` should be used to produce literal `:`s.'
   p.option 'internal_domains', '--internal-domains domain1,[domain2,...]', Array, 'A comma-separated list of Strings containing domains that will be treated as internal urls.'
+  p.option 'storage_dir', '--storage-dir PATH', String, 'Directory where to store the cache log (default: "tmp/.htmlproofer")'
 
   p.action do |args, opts|
     args = ['.'] if args.empty?
@@ -80,6 +81,7 @@ Mercenary.program(:htmlproofer) do |p|
 
     options[:cache] = {}
     options[:cache][:timeframe] = opts['timeframe'] unless opts['timeframe'].nil?
+    options[:cache][:storage_dir] = opts['storage_dir'] unless opts['storage_dir'].nil?
 
     options[:http_status_ignore] = Array(options[:http_status_ignore]).map(&:to_i)
 

--- a/lib/html-proofer/runner.rb
+++ b/lib/html-proofer/runner.rb
@@ -19,10 +19,6 @@ module HTMLProofer
       @type = @options.delete(:type)
       @logger = HTMLProofer::Log.new(@options[:log_level])
 
-      if !@options[:cache].empty? && !File.exist?(STORAGE_DIR)
-        FileUtils.mkdir_p(STORAGE_DIR)
-      end
-
       # Add swap patterns for internal domains
       unless @options[:internal_domains].empty?
         @options[:internal_domains].each do |dom|

--- a/lib/html-proofer/utils.rb
+++ b/lib/html-proofer/utils.rb
@@ -2,8 +2,6 @@ require 'nokogiri'
 
 module HTMLProofer
   module Utils
-    STORAGE_DIR = File.join('tmp', '.htmlproofer')
-
     def pluralize(count, single, plural)
       "#{count} " << (count == 1 ? single : plural)
     end

--- a/spec/html-proofer/cache_spec.rb
+++ b/spec/html-proofer/cache_spec.rb
@@ -2,93 +2,113 @@ require 'spec_helper'
 
 describe 'Cache test' do
 
-  it 'knows how to write to cache' do
-    stub_const('HTMLProofer::Cache::CACHE_LOG', "#{FIXTURES_DIR}/cache/.htmlproofer.log")
+  let(:storage_dir) { File.join(FIXTURES_DIR, "/cache") }
+  let(:cache_file) { File.join(storage_dir, cache_file_name) }
+  let(:cache_file_name) { HTMLProofer::Cache::DEFAULT_CACHE_FILE_NAME }
 
-    brokenLinkExternalFilepath = "#{FIXTURES_DIR}/links/brokenLinkExternal.html"
-    expect_any_instance_of(HTMLProofer::Cache).to receive(:write)
-    run_proofer(brokenLinkExternalFilepath, :file, :cache => { :timeframe => '30d' })
+  let(:default_cache_options) { { :storage_dir => storage_dir } }
 
-    log = read_cache
-    expect(log.keys.length).to eq(2)
-    statuses = log.values.map { |h| h['status'] }
-    expect(statuses.count(200)).to eq(1)
-    expect(statuses.count(0)).to eq(1)
+  def read_cache(cache_file)
+    JSON.parse File.read(cache_file)
+  end
+
+  context "with .htmlproofer.log" do
+    let(:cache_file_name) { ".htmlproofer.log" }
+
+    it 'knows how to write to cache' do
+      brokenLinkExternalFilepath = "#{FIXTURES_DIR}/links/brokenLinkExternal.html"
+      expect_any_instance_of(HTMLProofer::Cache).to receive(:write)
+      run_proofer(brokenLinkExternalFilepath, :file, :cache => { :timeframe => '30d', :cache_file => cache_file_name }.merge(default_cache_options))
+
+      log = read_cache(cache_file)
+      expect(log.keys.length).to eq(2)
+      statuses = log.values.map { |h| h['status'] }
+      expect(statuses.count(200)).to eq(1)
+      expect(statuses.count(0)).to eq(1)
+    end
   end
 
   it 'fails on an invalid date' do
     file = "#{FIXTURES_DIR}/links/brokenLinkExternal.html"
     expect {
-      run_proofer(file, :file, { :cache => { :timeframe => '30x' } })
+      run_proofer(file, :file, { :cache => { :timeframe => '30x' }.merge(default_cache_options) })
     }.to raise_error ArgumentError
   end
 
-  it 'does not write file if timestamp is within date' do
-    stub_const('HTMLProofer::Cache::CACHE_LOG', "#{FIXTURES_DIR}/cache/.within_date.log")
+  context "within date" do
+    let(:cache_file_name) { ".within_date.log" }
 
-    # this is frozen to within 7 days of the log
-    new_time = Time.local(2015, 10, 20, 12, 0, 0)
-    Timecop.freeze(new_time)
+    it 'does not write file if timestamp is within date' do
+      # this is frozen to within 7 days of the log
+      new_time = Time.local(2015, 10, 20, 12, 0, 0)
+      Timecop.freeze(new_time)
 
-    log = read_cache
-    current_time = log.values.first['time']
+      log = read_cache(cache_file)
+      current_time = log.values.first['time']
 
-    expect_any_instance_of(HTMLProofer::Cache).to receive(:write)
-    run_proofer(['www.github.com'], :links, { :cache => { :timeframe => '30d' } })
+      expect_any_instance_of(HTMLProofer::Cache).to receive(:write)
+      run_proofer(['www.github.com'], :links, { :cache => { :timeframe => '30d', :cache_file => cache_file_name }.merge(default_cache_options) })
 
-    # note that the timestamp did not change
-    log = read_cache
-    new_time = log.values.first['time']
-    expect(current_time).to eq(new_time)
+      # note that the timestamp did not change
+      log = read_cache(cache_file)
+      new_time = log.values.first['time']
+      expect(current_time).to eq(new_time)
 
-    Timecop.return
+      Timecop.return
+    end
   end
 
-  it 'does write file if timestamp is not within date' do
-    stub_const('HTMLProofer::Cache::CACHE_LOG', "#{FIXTURES_DIR}/cache/.not_within_date.log")
+  context "not within date" do
+    let(:cache_file_name) { ".not_within_date.log" }
 
-    # this is frozen to within 20 days after the log
-    new_time = Time.local(2014, 10, 21, 12, 0, 0)
-    Timecop.travel(new_time)
+    it 'does write file if timestamp is not within date' do
+      # this is frozen to within 20 days after the log
+      new_time = Time.local(2014, 10, 21, 12, 0, 0)
+      Timecop.travel(new_time)
 
-    # since the timestamp changed, we expect an add
-    expect_any_instance_of(HTMLProofer::Cache).to receive(:add)
-    run_proofer(['www.github.com'], :links, { :cache => { :timeframe => '4d' } })
+      # since the timestamp changed, we expect an add
+      expect_any_instance_of(HTMLProofer::Cache).to receive(:add)
+      run_proofer(['www.github.com'], :links, { :cache => { :timeframe => '4d', :cache_file => cache_file_name }.merge(default_cache_options) })
 
-    Timecop.return
+      Timecop.return
+    end
   end
 
-  it 'does write file if a new URL is added' do
-    stub_const('HTMLProofer::Cache::CACHE_LOG', "#{FIXTURES_DIR}/cache/.new_url.log")
+  context "new url added" do
+    let(:cache_file_name) { ".new_url.log" }
 
-    # this is frozen to within 7 days of the log
-    new_time = Time.local(2015, 10, 20, 12, 0, 0)
-    Timecop.freeze(new_time)
+    it 'does write file if a new URL is added' do
+      # this is frozen to within 7 days of the log
+      new_time = Time.local(2015, 10, 20, 12, 0, 0)
+      Timecop.freeze(new_time)
 
-    expect_any_instance_of(HTMLProofer::Cache).to receive(:write)
-    # we expect a new link to be added, but github.com can stay...
-    expect_any_instance_of(HTMLProofer::Cache).to receive(:add).with('www.google.com', nil, 200)
+      expect_any_instance_of(HTMLProofer::Cache).to receive(:write)
+      # we expect a new link to be added, but github.com can stay...
+      expect_any_instance_of(HTMLProofer::Cache).to receive(:add).with('www.google.com', nil, 200)
 
-    # ...because it's within the 30d time frame
-    run_proofer(['www.github.com', 'www.google.com'], :links, { :cache => { :timeframe => '30d' } })
+      # ...because it's within the 30d time frame
+      run_proofer(['www.github.com', 'www.google.com'], :links, { :cache => { :timeframe => '30d', :cache_file => cache_file_name }.merge(default_cache_options) })
 
-    Timecop.return
+      Timecop.return
+    end
   end
 
-  it 'does recheck failures, regardless of cache' do
-    stub_const('HTMLProofer::Cache::CACHE_LOG', "#{FIXTURES_DIR}/cache/.recheck_failure.log")
+  context "recheck failure" do
+    let(:cache_file_name) { ".recheck_failure.log" }
 
-    # this is frozen to within 7 days of the log
-    new_time = Time.local(2015, 10, 20, 12, 0, 0)
-    Timecop.freeze(new_time)
+    it 'does recheck failures, regardless of cache' do
+      # this is frozen to within 7 days of the log
+      new_time = Time.local(2015, 10, 20, 12, 0, 0)
+      Timecop.freeze(new_time)
 
-    expect_any_instance_of(HTMLProofer::Cache).to receive(:write)
-    # we expect the same link to be readded...
-    expect_any_instance_of(HTMLProofer::Cache).to receive(:add)
+      expect_any_instance_of(HTMLProofer::Cache).to receive(:write)
+      # we expect the same link to be readded...
+      expect_any_instance_of(HTMLProofer::Cache).to receive(:add)
 
-    # ...even though we are within the 30d time frame, because it's a failure
-    run_proofer(['http://www.foofoofoo.biz'], :links, { :cache => { :timeframe => '30d' } })
+      # ...even though we are within the 30d time frame, because it's a failure
+      run_proofer(['http://www.foofoofoo.biz'], :links, { :cache => { :timeframe => '30d', :cache_file => cache_file_name }.merge(default_cache_options) })
 
-    Timecop.return
+      Timecop.return
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,14 +69,6 @@ def make_bin(cmd, path=nil)
   `bin/htmlproofer #{cmd} #{path}`
 end
 
-def delete_cache
-  File.delete(HTMLProofer::Cache::CACHE_LOG) if File.exist?(HTMLProofer::Cache::CACHE_LOG)
-end
-
-def read_cache
-  JSON.parse File.read(HTMLProofer::Cache::CACHE_LOG)
-end
-
 def make_cassette_name(file, opts)
   filename = if file.is_a? Array
                file.join('_')


### PR DESCRIPTION
This PR will add a `--storage-dir` option where you can configure the directory where the cache log file will be read from and written to.

I took the liberty to update the cache specs a bit to be more idiomatic RSpec/Ruby. Most of the change was required because the cache log location is no longer a constant nor can it be injected via stubbing a constant.

Fixes https://github.com/gjtorikian/html-proofer/issues/369