### PR TITLE
Remove chomp URL from debug output

### DIFF
--- a/lib/html-proofer/url_validator.rb
+++ b/lib/html-proofer/url_validator.rb
@@ -162,7 +162,7 @@ module HTMLProofer
       else
         return if @options[:only_4xx] && !response_code.between?(400, 499)
         # Received a non-successful http response.
-        msg = "External link #{href.chomp('/')} failed: #{response_code} #{response.return_message}"
+        msg = "External link #{href} failed: #{response_code} #{response.return_message}"
         add_external_issue(filenames, msg, response_code)
         @cache.add(href, filenames, response_code, msg)
       end
@@ -185,21 +185,21 @@ module HTMLProofer
 
       return unless body_doc.xpath(xpath).empty?
 
-      msg = "External link #{href.chomp('/')} failed: #{effective_url} exists, but the hash '#{hash}' does not"
+      msg = "External link #{href} failed: #{effective_url} exists, but the hash '#{hash}' does not"
       add_external_issue(filenames, msg, response.code)
       @cache.add(href, filenames, response.code, msg)
       true
     end
 
     def handle_timeout(href, filenames, response_code)
-      msg = "External link #{href.chomp('/')} failed: got a time out (response code #{response_code})"
+      msg = "External link #{href} failed: got a time out (response code #{response_code})"
       @cache.add(href, filenames, 0, msg)
       return if @options[:only_4xx]
       add_external_issue(filenames, msg, response_code)
     end
 
     def handle_failure(href, filenames, response_code, return_message)
-      msg = "External link #{href.chomp('/')} failed: response code #{response_code} means something's wrong.
+      msg = "External link #{href} failed: response code #{response_code} means something's wrong.
              It's possible libcurl couldn't connect to the server or perhaps the request timed out.
              Sometimes, making too many requests at once also breaks things.
              Either way, the return message (if any) from the server is: #{return_message}"

--- a/spec/html-proofer/fixtures/links/brokenLinkExternal.html
+++ b/spec/html-proofer/fixtures/links/brokenLinkExternal.html
@@ -5,7 +5,7 @@
 	<p>Blah blah blah. <a href="http://www.google.com">Working link!</a></p>
 
 
-<a href="http://www.asdo3IRJ395295jsingrkrg4.com">broken link!</a>
+<a href="http://www.asdo3IRJ395295jsingrkrg4.com/">broken link!</a>
 </body>
 
 </html>

--- a/spec/html-proofer/fixtures/links/brokenLinkExternal.html
+++ b/spec/html-proofer/fixtures/links/brokenLinkExternal.html
@@ -5,7 +5,7 @@
 	<p>Blah blah blah. <a href="http://www.google.com">Working link!</a></p>
 
 
-<a href="http://www.asdo3IRJ395295jsingrkrg4.com/">broken link!</a>
+<a href="http://www.asdo3IRJ395295jsingrkrg4.com">broken link!</a>
 </body>
 
 </html>

--- a/spec/html-proofer/links_spec.rb
+++ b/spec/html-proofer/links_spec.rb
@@ -44,8 +44,8 @@ describe 'Links test' do
     proofer = run_proofer(brokenLinkExternalFilepath, :file)
     failure = proofer.failed_tests.first
     expect(failure).to match(/failed: response code 0/)
-    # ensure lack of slash in error message
-    expect(failure).to match(%r{External link http://www.asdo3IRJ395295jsingrkrg4.com failed:})
+    # ensure slash is added to redirected URL
+    expect(failure).to match(%r{External link http://www.asdo3IRJ395295jsingrkrg4.com/ failed:})
   end
 
   it 'passes for different filename without option' do


### PR DESCRIPTION
It doesn't seem to make much sense to `chomp` the URL in the debug output.

If I'm looking at the debug logs and it's saying that a particular URL has an error. I expect it to tell me the exact string of the URL that has the error -not a string that has been manipulated.