### PR TITLE
Escape quotes in anchors

### DIFF
--- a/lib/html-proofer/check/links.rb
+++ b/lib/html-proofer/check/links.rb
@@ -107,10 +107,12 @@ class LinkCheck < ::HTMLProofer::Check
 
   def hash_check(html, href_hash)
     decoded_href_hash = URI.decode(href_hash)
-    html.xpath("//*[case_insensitive_equals(@id, '#{href_hash}')]", \
-               "//*[case_insensitive_equals(@name, '#{href_hash}')]", \
-               "//*[case_insensitive_equals(@id, '#{decoded_href_hash}')]", \
-               "//*[case_insensitive_equals(@name, '#{decoded_href_hash}')]", \
+    href_hash = "'#{href_hash.split("'").join("', \"'\", '")}', ''"
+    decoded_href_hash = "'#{decoded_href_hash.split("'").join("', \"'\", '")}', ''"
+    html.xpath("//*[case_insensitive_equals(@id, concat(#{href_hash}))]", \
+               "//*[case_insensitive_equals(@name, concat(#{href_hash}))]", \
+               "//*[case_insensitive_equals(@id, concat(#{decoded_href_hash}))]", \
+               "//*[case_insensitive_equals(@name, concat(#{decoded_href_hash}))]", \
                XpathFunctions.new).length > 0
   end
 

--- a/spec/html-proofer/fixtures/links/quote.html
+++ b/spec/html-proofer/fixtures/links/quote.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<a id="let's-go" href="#let's-go"></a>
+</body>
+</html>

--- a/spec/html-proofer/links_spec.rb
+++ b/spec/html-proofer/links_spec.rb
@@ -499,9 +499,10 @@ describe 'Links test' do
     expect(proofer.failed_tests).to eq []
   end
 
-  it 'does not cgi encode link' do
-    prefetch = "#{FIXTURES_DIR}/links/do_not_cgi_encode.html"
-    proofer = run_proofer(prefetch, :file)
-    expect(proofer.failed_tests).to eq []
+  it 'works with quotes in the hash href' do
+    hash_href = "#{FIXTURES_DIR}/links/quote.html"
+    proofer = run_proofer(hash_href, :file, { :allow_hash_href => true })
+    expect(proofer.failed_tests.length).to eq 0
   end
+
 end


### PR DESCRIPTION
Having an id containing a quote is not allowed in HTML5. Having a quote currently crashes the link checking. This fix should solve that.