### PR TITLE
Set Typhoeus connection timeout, fixes #231, fixes #340

### DIFF
--- a/lib/html-proofer/configuration.rb
+++ b/lib/html-proofer/configuration.rb
@@ -34,7 +34,8 @@ module HTMLProofer
       :headers => {
         'User-Agent' => "Mozilla/5.0 (compatible; HTML Proofer/#{HTMLProofer::VERSION}; +https://github.com/gjtorikian/html-proofer)"
       },
-      :connecttimeout => 10
+      :connecttimeout => 10,
+      :timeout => 30
     }
 
     HYDRA_DEFAULTS = {

--- a/lib/html-proofer/configuration.rb
+++ b/lib/html-proofer/configuration.rb
@@ -34,6 +34,7 @@ module HTMLProofer
       :headers => {
         'User-Agent' => "Mozilla/5.0 (compatible; HTML Proofer/#{HTMLProofer::VERSION}; +https://github.com/gjtorikian/html-proofer)"
       }
+      :connecttimeout => 10
     }
 
     HYDRA_DEFAULTS = {

--- a/lib/html-proofer/configuration.rb
+++ b/lib/html-proofer/configuration.rb
@@ -33,7 +33,7 @@ module HTMLProofer
       :followlocation => true,
       :headers => {
         'User-Agent' => "Mozilla/5.0 (compatible; HTML Proofer/#{HTMLProofer::VERSION}; +https://github.com/gjtorikian/html-proofer)"
-      }
+      },
       :connecttimeout => 10
     }
 


### PR DESCRIPTION
If you can't even connect to the server in 10 seconds (5 internet-years), then fail that connection.

This should solve many people's problems with `htmlproofer` crashing their Travis builds.

The default are more than reasonable. And of course people can override the defaults by using the Ruby API.