### PR TITLE
Update nokogiri to v1.7

### DIFF
--- a/html-proofer.gemspec
+++ b/html-proofer.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'mercenary',       '~> 0.3.2'
-  gem.add_dependency 'nokogiri',        '~> 1.5'
+  gem.add_dependency 'nokogiri',        '~> 1.7'
   gem.add_dependency 'colored',         '~> 1.2'
   gem.add_dependency 'typhoeus',        '~> 0.7'
   gem.add_dependency 'yell',            '~> 2.0'

--- a/lib/html-proofer/version.rb
+++ b/lib/html-proofer/version.rb
@@ -1,3 +1,3 @@
 module HTMLProofer
-  VERSION = '3.6.0'.freeze
+  VERSION = '3.7.0'.freeze
 end


### PR DESCRIPTION
Do to a security [vulnerability in `nokogiri`](https://github.com/sparklemotion/nokogiri/issues/1615), this PR updates to that gem to the next safe version, `1.7`. 

I also updated the `html-proofer` version to `3.7.0`.

<img width="984" alt="screen shot 2017-03-29 at 4 25 34 pm" src="https://cloud.githubusercontent.com/assets/4803473/24477863/4e74f696-149e-11e7-9a90-f865ce092324.png">

cc @gjtorikian