### PR TITLE
handle base without href

### DIFF
--- a/lib/html-proofer/element.rb
+++ b/lib/html-proofer/element.rb
@@ -40,7 +40,7 @@ module HTMLProofer
       return @url if defined?(@url)
       @url = (@src || @srcset || @href || '').gsub("\u200b", '')
       if base
-        @url = Addressable::URI.join(base.attr('href'), url).to_s
+        @url = Addressable::URI.join(base.attr('href') || '', url).to_s
       end
       return @url if @check.options[:url_swap].empty?
       @url = swap(@url, @check.options[:url_swap])

--- a/spec/html-proofer/fixtures/links/base_no_href.html
+++ b/spec/html-proofer/fixtures/links/base_no_href.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+<base target="_blank">
+</head>
+<body>
+<a id="foo" href="#foo">OK</a>
+</body>
+</html>

--- a/spec/html-proofer/links_spec.rb
+++ b/spec/html-proofer/links_spec.rb
@@ -510,4 +510,10 @@ describe 'Links test' do
     proofer = run_proofer(hash_href, :file, { :allow_hash_href => true })
     expect(proofer.failed_tests.length).to eq 0
   end
+
+  it 'works with base without href' do
+    base_no_href = "#{FIXTURES_DIR}/links/base_no_href.html"
+    proofer = run_proofer(base_no_href, :file)
+    expect(proofer.failed_tests).to eq []
+  end
 end


### PR DESCRIPTION
[`<base>`](https://html.spec.whatwg.org/multipage/semantics.html#the-base-element) can have `href` and/or `target` attributes. Currently, `href` is not present obtains:

> htmlproofer 3.6.0 | Error:  Can't convert NilClass into String.

This PR allows `<base>` to not have an `href` attribute.