### PR TITLE
support links to the #top of pages

### DIFF
--- a/lib/html-proofer/check/links.rb
+++ b/lib/html-proofer/check/links.rb
@@ -107,13 +107,20 @@ class LinkCheck < ::HTMLProofer::Check
 
   def hash_check(html, href_hash)
     decoded_href_hash = URI.decode(href_hash)
-    href_hash = "'#{href_hash.split("'").join("', \"'\", '")}', ''"
-    decoded_href_hash = "'#{decoded_href_hash.split("'").join("', \"'\", '")}', ''"
-    html.xpath("//*[case_insensitive_equals(@id, concat(#{href_hash}))]", \
-               "//*[case_insensitive_equals(@name, concat(#{href_hash}))]", \
-               "//*[case_insensitive_equals(@id, concat(#{decoded_href_hash}))]", \
-               "//*[case_insensitive_equals(@name, concat(#{decoded_href_hash}))]", \
-               XpathFunctions.new).length > 0
+    find_fragments(html, [href_hash, decoded_href_hash]).length > 0
+  end
+
+  def find_fragments(html, fragment_ids)
+    xpaths = fragment_ids.flat_map do |frag_id|
+      escaped_frag_id = "'#{frag_id.split("'").join("', \"'\", '")}', ''"
+      [
+        "//*[case_insensitive_equals(@id, concat(#{escaped_frag_id}))]",
+        "//*[case_insensitive_equals(@name, concat(#{escaped_frag_id}))]"
+      ]
+    end
+    xpaths << XpathFunctions.new
+
+    html.xpath(*xpaths)
   end
 
   class XpathFunctions

--- a/lib/html-proofer/check/links.rb
+++ b/lib/html-proofer/check/links.rb
@@ -107,7 +107,8 @@ class LinkCheck < ::HTMLProofer::Check
 
   def hash_check(html, href_hash)
     decoded_href_hash = URI.decode(href_hash)
-    find_fragments(html, [href_hash, decoded_href_hash]).length > 0
+    fragment_ids = [href_hash, decoded_href_hash]
+    fragment_ids.include?('top') || find_fragments(html, fragment_ids).length > 0
   end
 
   def find_fragments(html, fragment_ids)

--- a/spec/html-proofer/fixtures/links/githubHash.html
+++ b/spec/html-proofer/fixtures/links/githubHash.html
@@ -1,1 +1,2 @@
 <a href="https://github.com/typhoeus/typhoeus#other-curl-options">This gets converted</a>.
+<a href="https://github.com/typhoeus/typhoeus#top">This gets converted</a>.

--- a/spec/html-proofer/fixtures/links/topHashInternal.html
+++ b/spec/html-proofer/fixtures/links/topHashInternal.html
@@ -1,0 +1,7 @@
+<html>
+
+<body>
+
+<p>Blah blah blah. <a href="#top">A real link to the top!</a></p>
+
+</html>

--- a/spec/html-proofer/fixtures/vcr_cassettes/links/githubHash_html_log_level_error_type_file_.yml
+++ b/spec/html-proofer/fixtures/vcr_cassettes/links/githubHash_html_log_level_error_type_file_.yml
@@ -71,4 +71,76 @@ http_interactions:
     adapter_metadata:
       effective_url: https://github.com/typhoeus/typhoeus
   recorded_at: Sat, 13 Feb 2016 14:51:06 GMT
+- request:
+    method: head
+    uri: https://github.com/typhoeus/typhoeus#top
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/3.6.0; +https://github.com/gjtorikian/html-proofer)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Tue, 25 Apr 2017 20:32:36 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Status:
+      - 200 OK
+      Cache-Control:
+      - no-cache
+      Vary:
+      - X-PJAX
+      - Accept-Encoding
+      X-UA-Compatible:
+      - IE=Edge,chrome=1
+      Set-Cookie:
+      - logged_in=no; domain=.github.com; path=/; expires=Sat, 25 Apr 2037 20:32:36
+        -0000; secure; HttpOnly
+      - _gh_sess=eyJzZXNzaW9uX2lkIjoiMDg4NzA4OGEwY2VmZDk2YzhkZTgzZTUwNjE0ODkzOTIiLCJzcHlfcmVwbyI6InR5cGhvZXVzL3R5cGhvZXVzIiwic3B5X3JlcG9fYXQiOjE0OTMxNTIzNTYsIl9jc3JmX3Rva2VuIjoiVGdhZXBXRkFPdmVDVkNjUmlhaFdpM2JPZEs4VVJUSytsUFVJdjZ0WkRaOD0iLCJmbGFzaCI6eyJkaXNjYXJkIjpbImFuYWx5dGljc19sb2NhdGlvbiJdLCJmbGFzaGVzIjp7ImFuYWx5dGljc19sb2NhdGlvbiI6Ii88dXNlci1uYW1lPi88cmVwby1uYW1lPiJ9fX0%3D--1388bfb1981aebadca8b2f6986fc9f08e7952648;
+        path=/; secure; HttpOnly
+      X-Request-Id:
+      - '08491c820751f6b03cb5c991f169a829'
+      X-Runtime:
+      - '0.105493'
+      Content-Security-Policy:
+      - 'default-src ''none''; base-uri ''self''; block-all-mixed-content; child-src
+        render.githubusercontent.com; connect-src ''self'' uploads.github.com status.github.com
+        collector.githubapp.com api.github.com www.google-analytics.com github-cloud.s3.amazonaws.com
+        wss://live.github.com; font-src assets-cdn.github.com; form-action ''self''
+        github.com gist.github.com; frame-ancestors ''none''; img-src ''self'' data:
+        assets-cdn.github.com identicons.github.com collector.githubapp.com github-cloud.s3.amazonaws.com
+        *.githubusercontent.com; media-src ''none''; script-src assets-cdn.github.com;
+        style-src ''unsafe-inline'' assets-cdn.github.com'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Public-Key-Pins:
+      - max-age=5184000; pin-sha256="WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=";
+        pin-sha256="RRM1dGqnDFsCJXBTHky16vi1obOlCgFFn/yOhI/y+ho="; pin-sha256="k2v657xBsOVe1PQRwOsHsw3bsGT2VzIqz5K+59sNQws=";
+        pin-sha256="K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q="; pin-sha256="IQBnNBEiFuhj+8x6X8XLgh01V9Ic5/V3IRQLNFFc7v4=";
+        pin-sha256="iie1VXtL7HzAMF+/PVPR9xzT80kQxdZeJ+zduCB3uj0="; pin-sha256="LvRiGEjRqfzurezaWuj8Wie2gyHMrW5Q06LspMnox7A=";
+        includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-XSS-Protection:
+      - 1; mode=block
+      X-Served-By:
+      - 93e250bfa62a70489edea0a57475ced6
+      X-GitHub-Request-Id:
+      - EF85:309D:5AA2C3B:86E2427:58FFB264
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://github.com/typhoeus/typhoeus
+  recorded_at: Tue, 25 Apr 2017 20:32:36 GMT
 recorded_with: VCR 2.9.3

--- a/spec/html-proofer/links_spec.rb
+++ b/spec/html-proofer/links_spec.rb
@@ -39,6 +39,12 @@ describe 'Links test' do
     expect(proofer.failed_tests.first).to match(/linking to internal hash #noHash that does not exist/)
   end
 
+  it 'passes when linking to the top' do
+    path = "#{FIXTURES_DIR}/links/topHashInternal.html"
+    proofer = run_proofer(path, :file)
+    expect(proofer.failed_tests).to eq []
+  end
+
   it 'fails for broken external links' do
     brokenLinkExternalFilepath = "#{FIXTURES_DIR}/links/brokenLinkExternal.html"
     proofer = run_proofer(brokenLinkExternalFilepath, :file)


### PR DESCRIPTION
Per the HTML5 spec:

> If `fragid` is an ASCII case-insensitive match for the string `top`, then the indicated part of the document is the top of the document

https://www.w3.org/TR/html5/single-page.html#scroll-to-fragid

/cc #118