### PR TITLE
Document difference between command line and Ruby implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ In scope for this project is any well-known and widely-used test for HTML docume
 
 **Third-party modules.** We want this product to be useful for continuous integration so we prefer to avoid subjective tests which are prone to false positive results, such as spell checkers, indentation checkers, etc. If you want to work on these items, please see [the section on custom tests](#custom-tests) and consider adding an implementation as a third-party module.
 
+**Advanced configuration.** Most front-end developers can test their HTML using [our command line program](#using-on-the-command-line). Advanced configuration will [require using Ruby](https://github.com/gjtorikian/html-proofer/wiki/Using-HTMLProofer-From-Ruby-and-Travis).
+
 ## Installation
 
 Add this line to your application's Gemfile:


### PR DESCRIPTION
This change to the project scope clarifies that "advanced" usage of this project will require using Ruby.

It would allow us to close issues as out of scope:

* #408 
* #379 
* #194 

Also it will allow us to accept a change to the README which would simplify the recommended use case (command line) while allowing further, advanced discussion in a separate file or wiki like https://github.com/gjtorikian/html-proofer/wiki/Using-HTMLProofer-From-Ruby-and-Travis