### PR TITLE
Send a sensible Accept header when testing external links

### DIFF
--- a/lib/html-proofer/configuration.rb
+++ b/lib/html-proofer/configuration.rb
@@ -32,7 +32,8 @@ module HTMLProofer
     TYPHOEUS_DEFAULTS = {
       followlocation: true,
       headers: {
-        'User-Agent' => "Mozilla/5.0 (compatible; HTML Proofer/#{HTMLProofer::VERSION}; +https://github.com/gjtorikian/html-proofer)"
+        'User-Agent' => "Mozilla/5.0 (compatible; HTML Proofer/#{HTMLProofer::VERSION}; +https://github.com/gjtorikian/html-proofer)",
+        'Accept' => 'application/xml,application/xhtml+xml,text/html;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5'
       },
       connecttimeout: 10,
       timeout: 30


### PR DESCRIPTION
When testing external links, we currently send a `User-Agent` but no `Accept` header, which specifies the kind of content we want to get back.

This causes problems with testing some URLs, since they return a 404 (or other 4XX error code) as they don't know what format to return in.

This adds a default value, using the header [sent by Chrome and Safari](https://developer.mozilla.org/en-US/docs/Web/HTTP/Content_negotiation/List_of_default_Accept_values) as a sensible default.