### PR TITLE
Ignore Jekyll redirect_from template from favicon check

### DIFF
--- a/lib/html-proofer/check/favicon.rb
+++ b/lib/html-proofer/check/favicon.rb
@@ -10,6 +10,10 @@ class FaviconCheck < ::HTMLProofer::Check
 
     return if found
 
+    # specific match for Jekyll's redirect_from template:
+    # https://git.io/v5stq
+    return if @html.xpath('//title').text == "Redirecting…"
+
     add_issue('no favicon specified')
   end
 end

--- a/lib/html-proofer/check/favicon.rb
+++ b/lib/html-proofer/check/favicon.rb
@@ -12,7 +12,7 @@ class FaviconCheck < ::HTMLProofer::Check
 
     # specific match for Jekyll's redirect_from template:
     # https://git.io/v5stq
-    return if @html.xpath('//title').text == "Redirecting…"
+    return if @html.xpath('//title').text == 'Redirecting…'
 
     add_issue('no favicon specified')
   end

--- a/spec/html-proofer/favicon_spec.rb
+++ b/spec/html-proofer/favicon_spec.rb
@@ -54,4 +54,10 @@ describe 'Favicons test' do
     proofer = run_proofer(broken_but_ignored, :file, check_favicon: true)
     expect(proofer.failed_tests.first).to match(/no favicon specified/)
   end
+
+  it 'specifically ignores jekyll redirect_from template' do
+    broken_but_ignored = "#{FIXTURES_DIR}/favicon/jekyll_redirect_from.html"
+    proofer = run_proofer(broken_but_ignored, :file, check_favicon: true)
+    expect(proofer.failed_tests).to eq []
+  end
 end

--- a/spec/html-proofer/fixtures/favicon/jekyll_redirect_from.html
+++ b/spec/html-proofer/fixtures/favicon/jekyll_redirect_from.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <meta http-equiv="refresh" content="0; url={{ page.redirect.to }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <script>location="{{ page.redirect.to }}"</script>
+</html>


### PR DESCRIPTION
Closes https://github.com/gjtorikian/html-proofer/issues/446, though it is extraordinarily brittle, there's not much else that can be done. 