### PR TITLE
Change to use colorize gem

### DIFF
--- a/html-proofer.gemspec
+++ b/html-proofer.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'mercenary',       '~> 0.3.2'
   gem.add_dependency 'nokogiri',        '~> 1.7'
-  gem.add_dependency 'colored',         '~> 1.2'
+  gem.add_dependency 'colorize',        '~> 0.8'
   gem.add_dependency 'typhoeus',        '~> 0.7'
   gem.add_dependency 'yell',            '~> 2.0'
   gem.add_dependency 'parallel',        '~> 1.3'

--- a/lib/html-proofer/log.rb
+++ b/lib/html-proofer/log.rb
@@ -1,5 +1,5 @@
 require 'yell'
-require 'colored'
+require 'colorized_string'
 
 module HTMLProofer
   class Log
@@ -35,7 +35,7 @@ module HTMLProofer
 
     def colorize(color, message)
       if $stdout.isatty && $stderr.isatty
-        Colored.colorize(message, foreground: color)
+        ColorizedString.new(message).colorize(color)
       else
         message
       end


### PR DESCRIPTION
Colored is no longer maintained. Resolves #449, and will prevent a bunch of outdated dependency warnings for people using html-proofer.

There currently aren't any tests for the `Log` class, as far as I can see. Would you want some added in order to merge this?