### PR TITLE
dropping url.chomp('/') which cause 301s

### DIFF
--- a/html-proofer.gemspec
+++ b/html-proofer.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'mercenary',       '~> 0.3.2'
   gem.add_dependency 'nokogiri',        '~> 1.7'
   gem.add_dependency 'colorize',        '~> 0.8'
-  gem.add_dependency 'typhoeus',        '~> 0.7'
+  gem.add_dependency 'typhoeus',        '~> 1.3'
   gem.add_dependency 'yell',            '~> 2.0'
   gem.add_dependency 'parallel',        '~> 1.3'
   gem.add_dependency 'addressable',     '~> 2.3'

--- a/lib/html-proofer/cache.rb
+++ b/lib/html-proofer/cache.rb
@@ -128,12 +128,6 @@ module HTMLProofer
       urls_to_check
     end
 
-    # FIXME: there seems to be some discrepenacy where Typhoeus occasionally adds
-    # a trailing slash to URL strings, which causes issues with the cache
-    def slashless_url(url)
-      url.chomp('/')
-    end
-
     # FIXME: it seems that Typhoeus actually acts on escaped URLs,
     # but there's no way to get at that information, and the cache
     # stores unescaped URLs. Because of this, some links, such as
@@ -144,7 +138,7 @@ module HTMLProofer
     end
 
     def clean_url(url)
-      slashless_url(unescape_url(url))
+      unescape_url(url)
     end
 
     def setup_cache!(options)

--- a/lib/html-proofer/url_validator.rb
+++ b/lib/html-proofer/url_validator.rb
@@ -163,7 +163,7 @@ module HTMLProofer
       else
         return if @options[:only_4xx] && !response_code.between?(400, 499)
         # Received a non-successful http response.
-        msg = "External link #{href.chomp('/')} failed: #{response_code} #{response.return_message}"
+        msg = "External link #{href} failed: #{response_code} #{response.return_message}"
         add_external_issue(filenames, msg, response_code)
         @cache.add(href, filenames, response_code, msg)
       end
@@ -186,21 +186,21 @@ module HTMLProofer
 
       return unless body_doc.xpath(xpath).empty?
 
-      msg = "External link #{href.chomp('/')} failed: #{effective_url} exists, but the hash '#{hash}' does not"
+      msg = "External link #{href} failed: #{effective_url} exists, but the hash '#{hash}' does not"
       add_external_issue(filenames, msg, response.code)
       @cache.add(href, filenames, response.code, msg)
       true
     end
 
     def handle_timeout(href, filenames, response_code)
-      msg = "External link #{href.chomp('/')} failed: got a time out (response code #{response_code})"
+      msg = "External link #{href} failed: got a time out (response code #{response_code})"
       @cache.add(href, filenames, 0, msg)
       return if @options[:only_4xx]
       add_external_issue(filenames, msg, response_code)
     end
 
     def handle_failure(href, filenames, response_code, return_message)
-      msg = "External link #{href.chomp('/')} failed: response code #{response_code} means something's wrong.
+      msg = "External link #{href} failed: response code #{response_code} means something's wrong.
              It's possible libcurl couldn't connect to the server or perhaps the request timed out.
              Sometimes, making too many requests at once also breaks things.
              Either way, the return message (if any) from the server is: #{return_message}"

--- a/spec/html-proofer/links_spec.rb
+++ b/spec/html-proofer/links_spec.rb
@@ -49,8 +49,7 @@ describe 'Links test' do
     proofer = run_proofer(broken_link_external_filepath, :file)
     failure = proofer.failed_tests.first
     expect(failure).to match(/failed: response code 0/)
-    # ensure lack of slash in error message
-    expect(failure).to match(%r{External link http://www.asdo3IRJ395295jsingrkrg4.com failed:})
+    expect(failure).to match(%r{External link http://www.asdo3IRJ395295jsingrkrg4.com/ failed:})
   end
 
   it 'passes for different filename without option' do
@@ -559,7 +558,7 @@ describe 'Links test' do
 
   it 'timeout' do
     proofer = run_proofer(['https://www.google.com:81'], :links)
-    expect(proofer.failed_tests.first).to match(/time out/)
+    expect(proofer.failed_tests.first).to match(/Couldn't connect to server/)
   end
 
   it 'correctly handles empty href' do


### PR DESCRIPTION
And upgrading typhoeus

to solve https://github.com/gjtorikian/html-proofer/pull/398#issuecomment-349415894