### PR TITLE
Update nokogiri to ~> 1.8.1 (CVE-2017-9050)

### DIFF
--- a/html-proofer.gemspec
+++ b/html-proofer.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'mercenary',       '~> 0.3.2'
-  gem.add_dependency 'nokogiri',        '~> 1.7'
+  gem.add_dependency 'nokogiri',        '~> 1.8.1'
   gem.add_dependency 'colorize',        '~> 0.8'
   gem.add_dependency 'typhoeus',        '~> 0.7'
   gem.add_dependency 'yell',            '~> 2.0'


### PR DESCRIPTION
Nokogiri 1.8.0 and below contains a vulnerability (http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-9050, https://security.gentoo.org/glsa/201711-01) reported by GitHub via e-mail today. This upgrades nokogiri to the new, patched version.

I'm not a Ruby expert, so this is mostly just to get the ball rolling. I don't think I would know what to do if it fails…