### PR TITLE
Improve / Fix Example Code in README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ docs/
 _yardoc
 doc/
 .DS_Store
+.idea

--- a/README.md
+++ b/README.md
@@ -390,11 +390,12 @@ Here's an example custom test demonstrating these concepts. It reports `mailto` 
 ``` ruby
 class MailToOctocat < ::HTMLProofer::Check
   def mailto?
-    return false if @link.data_ignore_proofer || @link.href.nil?
+    return false if @link.data_proofer_ignore || @link.href.nil?
     @link.href.match /mailto/
   end
 
   def octocat?
+    return false if @link.data_proofer_ignore || @link.href.nil?
     @link.href.match /octocat@github.com/
   end
 


### PR DESCRIPTION
While trying out I found that the example code for a custom check in the README does not actually run.   It's mainly a word order typo.   

I added the check for nil to the oktopost example, too because it's suspectible to the same issues - but that's optional and could be left out for conciseness sake. 

If you want you can take over the .gitignore addition for JetBrains RubyMine IDE users, too. But that's just cosmetics.  