### PR TITLE
Allow skipping the `href` requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ The `HTMLProofer` constructor takes an optional hash of additional options:
 
 | Option | Description | Default |
 | :----- | :---------- | :------ |
+| `allow_missing_href` | If `true`, does not flag `a` tags missing `href` (this is the default for HTML5). | `false` |
 | `allow_hash_href` | If `true`, ignores the `href` `#`. | `false` |
 | `alt_ignore` | An array of Strings or RegExps containing `img`s whose missing `alt` tags are safe to ignore. | `[]` |
 | `assume_extension` | Automatically add extension (e.g. `.html`) to file paths, to allow extensionless URLs (as supported by Jekyll 3 and GitHub Pages) | `false` |

--- a/bin/htmlproofer
+++ b/bin/htmlproofer
@@ -13,6 +13,7 @@ Mercenary.program(:htmlproofer) do |p|
 
   p.description 'Runs the HTML-Proofer suite on the files in PATH. For more details, see the README.'
 
+  p.option 'allow_missing_href', '--allow-missing-href', 'If `true`, does not flag `a` tags missing `href` (this is the default for HTML5).'
   p.option 'allow_hash_href', '--allow-hash-href', 'If `true`, ignores the `href` `#`'
   p.option 'as_links', '--as-links', 'Assumes that `PATH` is a comma-separated array of links to check.'
   p.option 'alt_ignore', '--alt-ignore image1,[image2,...]', Array, 'A comma-separated list of Strings or RegExps containing `img`s whose missing `alt` tags are safe to ignore'

--- a/lib/html-proofer.rb
+++ b/lib/html-proofer.rb
@@ -1,5 +1,3 @@
-# rubocop:disable Naming/FileName
-
 def require_all(path)
   dir = File.join(File.dirname(__FILE__), path)
   Dir[File.join(dir, '*.rb')].each do |f|

--- a/lib/html-proofer/check/links.rb
+++ b/lib/html-proofer/check/links.rb
@@ -30,6 +30,7 @@ class LinkCheck < ::HTMLProofer::Check
 
       # is there even an href?
       if missing_href?
+        next if @link.allow_missing_href?
         # HTML5 allows dropping the href: http://git.io/vBX0z
         next if @html.internal_subset.name == 'html' && @html.internal_subset.external_id.nil?
         add_issue('anchor has no href attribute', line: line, content: content)

--- a/lib/html-proofer/configuration.rb
+++ b/lib/html-proofer/configuration.rb
@@ -3,6 +3,7 @@ module HTMLProofer
     require_relative 'version'
 
     PROOFER_DEFAULTS = {
+      allow_missing_href: false,
       allow_hash_href: false,
       alt_ignore: [],
       assume_extension: false,

--- a/lib/html-proofer/element.rb
+++ b/lib/html-proofer/element.rb
@@ -114,6 +114,10 @@ module HTMLProofer
       @check.options[:empty_alt_ignore]
     end
 
+    def allow_missing_href?
+      @check.options[:allow_missing_href]
+    end
+
     def allow_hash_href?
       @check.options[:allow_hash_href]
     end

--- a/spec/html-proofer/links_spec.rb
+++ b/spec/html-proofer/links_spec.rb
@@ -484,6 +484,16 @@ describe 'Links test' do
     expect(proofer.failed_tests.length).to eq 1
   end
 
+  it 'can skip expecting href for anchors in non-HTML5' do
+    missing_href = "#{FIXTURES_DIR}/links/blank_href_html4.html"
+    proofer = run_proofer(missing_href, :file, allow_missing_href: true)
+    expect(proofer.failed_tests.length).to eq 0
+
+    missing_href = "#{FIXTURES_DIR}/links/blank_href_htmlunknown.html"
+    proofer = run_proofer(missing_href, :file, allow_missing_href: true)
+    expect(proofer.failed_tests.length).to eq 0
+  end
+
   it 'works with internal_domains' do
     translated_link = "#{FIXTURES_DIR}/links/link_translated_internal_domains.html"
     proofer = run_proofer(translated_link, :file, internal_domains: ['www.example.com', 'example.com'])


### PR DESCRIPTION
Closes https://github.com/gjtorikian/html-proofer/issues/474.