### PR TITLE
don't File.read directories

### DIFF
--- a/lib/html-proofer/utils.rb
+++ b/lib/html-proofer/utils.rb
@@ -7,7 +7,7 @@ module HTMLProofer
     end
 
     def create_nokogiri(path)
-      content = if File.exist? path
+      content = if File.exist?(path) && !File.directory?(path)
                   File.open(path).read
                 else
                   path

--- a/spec/html-proofer/utils_spec.rb
+++ b/spec/html-proofer/utils_spec.rb
@@ -10,5 +10,9 @@ describe HTMLProofer::Utils do
       noko = HTMLProofer::Utils.create_nokogiri "#{FIXTURES_DIR}/utils/lang-jp.html"
       expect(noko.css('html').first['lang']).to eq 'jp'
     end
+    it 'ignores directories' do
+      noko = HTMLProofer::Utils.create_nokogiri "#{FIXTURES_DIR}/utils"
+      expect(noko.content).to eq 'spec/html-proofer/fixtures/utils'
+    end
   end
 end

--- a/spec/html-proofer/utils_spec.rb
+++ b/spec/html-proofer/utils_spec.rb
@@ -6,10 +6,12 @@ describe HTMLProofer::Utils do
       noko = HTMLProofer::Utils.create_nokogiri '<html lang="jp">'
       expect(noko.css('html').first['lang']).to eq 'jp'
     end
+    
     it 'passes for a file' do
       noko = HTMLProofer::Utils.create_nokogiri "#{FIXTURES_DIR}/utils/lang-jp.html"
       expect(noko.css('html').first['lang']).to eq 'jp'
     end
+    
     it 'ignores directories' do
       noko = HTMLProofer::Utils.create_nokogiri "#{FIXTURES_DIR}/utils"
       expect(noko.content).to eq 'spec/html-proofer/fixtures/utils'


### PR DESCRIPTION
I was trying out 3.9.0 and ran into the following error: `utils.rb:11:in `read': Is a directory @ io_fread`

This fixes that so it won't blow up anymore. 

<details>
<summary>Traceback</summary>

```
Traceback (most recent call last):
	27: from /usr/local/bin/htmlproofer:23:in `<main>'
	26: from /usr/local/bin/htmlproofer:23:in `load'
	25: from /usr/local/lib/ruby/gems/2.5.0/gems/html-proofer-3.7.6/bin/htmlproofer:9:in `<top (required)>'
	24: from /usr/local/lib/ruby/gems/2.5.0/gems/mercenary-0.3.6/lib/mercenary.rb:19:in `program'
	23: from /usr/local/lib/ruby/gems/2.5.0/gems/mercenary-0.3.6/lib/mercenary/program.rb:42:in `go'
	22: from /usr/local/lib/ruby/gems/2.5.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `execute'
	21: from /usr/local/lib/ruby/gems/2.5.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `each'
	20: from /usr/local/lib/ruby/gems/2.5.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `block in execute'
	19: from /usr/local/lib/ruby/gems/2.5.0/gems/html-proofer-3.7.6/bin/htmlproofer:93:in `block (2 levels) in <top (required)>'
	18: from /usr/local/lib/ruby/gems/2.5.0/gems/html-proofer-3.7.6/lib/html-proofer/runner.rb:40:in `run'
	17: from /usr/local/lib/ruby/gems/2.5.0/gems/html-proofer-3.7.6/lib/html-proofer/runner.rb:68:in `check_files'
	16: from /usr/local/lib/ruby/gems/2.5.0/gems/html-proofer-3.7.6/lib/html-proofer/runner.rb:87:in `process_files'
	15: from /usr/local/lib/ruby/gems/2.5.0/gems/html-proofer-3.7.6/lib/html-proofer/runner.rb:87:in `map'
	14: from /usr/local/lib/ruby/gems/2.5.0/gems/html-proofer-3.7.6/lib/html-proofer/runner.rb:87:in `block in process_files'
	13: from /usr/local/lib/ruby/gems/2.5.0/gems/html-proofer-3.7.6/lib/html-proofer/runner.rb:99:in `check_path'
	12: from /usr/local/lib/ruby/gems/2.5.0/gems/html-proofer-3.7.6/lib/html-proofer/runner.rb:99:in `each'
	11: from /usr/local/lib/ruby/gems/2.5.0/gems/html-proofer-3.7.6/lib/html-proofer/runner.rb:100:in `block in check_path'
	10: from /usr/local/lib/ruby/gems/2.5.0/gems/html-proofer-3.7.6/lib/html-proofer/runner.rb:100:in `each'
	 9: from /usr/local/lib/ruby/gems/2.5.0/gems/html-proofer-3.7.6/lib/html-proofer/runner.rb:103:in `block (2 levels) in check_path'
	 8: from /usr/local/lib/ruby/gems/2.5.0/gems/html-proofer-3.7.6/lib/html-proofer/check/links.rb:13:in `run'
	 7: from /usr/local/lib/ruby/gems/2.5.0/gems/nokogiri-1.8.2/lib/nokogiri/xml/node_set.rb:189:in `each'
	 6: from /usr/local/lib/ruby/gems/2.5.0/gems/nokogiri-1.8.2/lib/nokogiri/xml/node_set.rb:189:in `upto'
	 5: from /usr/local/lib/ruby/gems/2.5.0/gems/nokogiri-1.8.2/lib/nokogiri/xml/node_set.rb:190:in `block in each'
	 4: from /usr/local/lib/ruby/gems/2.5.0/gems/html-proofer-3.7.6/lib/html-proofer/check/links.rb:60:in `block in run'
	 3: from /usr/local/lib/ruby/gems/2.5.0/gems/html-proofer-3.7.6/lib/html-proofer/check/links.rb:94:in `handle_hash'
	 2: from /usr/local/lib/ruby/gems/2.5.0/gems/html-proofer-3.7.6/lib/html-proofer/check/links.rb:102:in `external_link_check'
	 1: from /usr/local/lib/ruby/gems/2.5.0/gems/html-proofer-3.7.6/lib/html-proofer/utils.rb:11:in `create_nokogiri'
/usr/local/lib/ruby/gems/2.5.0/gems/html-proofer-3.7.6/lib/html-proofer/utils.rb:11:in `read': Is a directory @ io_fread - /Users/adam/code/src/github.com/banno/wiki/_site/nodejs/DependenciesAndTasks (Errno::EISDIR)
```

</details> 