### PR TITLE
Changed description of allow_hash_href option

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ The `HTMLProofer` constructor takes an optional hash of additional options:
 | Option | Description | Default |
 | :----- | :---------- | :------ |
 | `allow_missing_href` | If `true`, does not flag `a` tags missing `href` (this is the default for HTML5). | `false` |
-| `allow_hash_href` | If `true`, ignores the `href` `#`. | `false` |
+| `allow_hash_href` | If `true`, ignores the `href="#"`. | `false` |
 | `alt_ignore` | An array of Strings or RegExps containing `img`s whose missing `alt` tags are safe to ignore. | `[]` |
 | `assume_extension` | Automatically add extension (e.g. `.html`) to file paths, to allow extensionless URLs (as supported by Jekyll 3 and GitHub Pages) | `false` |
 | `check_external_hash` | Checks whether external hashes exist (even if the webpage exists). This slows the checker down. | `false` |

--- a/bin/htmlproofer
+++ b/bin/htmlproofer
@@ -14,7 +14,7 @@ Mercenary.program(:htmlproofer) do |p|
   p.description 'Runs the HTML-Proofer suite on the files in PATH. For more details, see the README.'
 
   p.option 'allow_missing_href', '--allow-missing-href', 'If `true`, does not flag `a` tags missing `href` (this is the default for HTML5).'
-  p.option 'allow_hash_href', '--allow-hash-href', 'If `true`, ignores the `href` `#`'
+  p.option 'allow_hash_href', '--allow-hash-href', 'If `true`, ignores the `href="#"`'
   p.option 'as_links', '--as-links', 'Assumes that `PATH` is a comma-separated array of links to check.'
   p.option 'alt_ignore', '--alt-ignore image1,[image2,...]', Array, 'A comma-separated list of Strings or RegExps containing `img`s whose missing `alt` tags are safe to ignore'
   p.option 'assume_extension', '--assume-extension', 'Automatically add extension (e.g. `.html`) to file paths, to allow extensionless URLs (as supported by Jekyll 3 and GitHub Pages) (default: `false`).'


### PR DESCRIPTION
Previous description is not clear about if it allows only "#" or also strings starting with "#". My version seems more clear for me. :-)