### PR TITLE
Support Typhoeus options from command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ The `HTMLProofer` constructor takes an optional hash of additional options:
 | `url_ignore` | An array of Strings or RegExps containing URLs that are safe to ignore. It affects all HTML attributes. Note that non-HTTP(S) URIs are always ignored. | `[]` |
 | `url_swap` | A hash containing key-value pairs of `RegExp => String`. It transforms URLs that match `RegExp` into `String` via `gsub`. | `{}` |
 | `verbose` | If `true`, outputs extra information as the checking happens. Useful for debugging. **Will be deprecated in a future release.**| `false` |
+| `typhoeus_config` | A JSON-formatted string. Parsed using `JSON.parse` and mapped on top of the default configuration values so that they can be overridden. | `{}` |
 
 In addition, there are a few "namespaced" options. These are:
 

--- a/bin/htmlproofer
+++ b/bin/htmlproofer
@@ -44,6 +44,7 @@ Mercenary.program(:htmlproofer) do |p|
   p.option 'url_swap', '--url-swap re:string,[re:string,...]', Array, 'A comma-separated list containing key-value pairs of `RegExp => String`. It transforms URLs that match `RegExp` into `String` via `gsub`. The escape sequences `\\:` should be used to produce literal `:`s.'
   p.option 'internal_domains', '--internal-domains domain1,[domain2,...]', Array, 'A comma-separated list of Strings containing domains that will be treated as internal urls.'
   p.option 'storage_dir', '--storage-dir PATH', String, 'Directory where to store the cache log (default: "tmp/.htmlproofer")'
+  p.option 'typhoeus_config', '--typhoeus-config CONFIG', String, 'JSON-formatted string of Typhoeus config. Will override the html-proofer defaults.'
 
   p.action do |args, opts|
     args = ['.'] if args.empty?
@@ -79,6 +80,9 @@ Mercenary.program(:htmlproofer) do |p|
     options[:validation][:report_script_embeds] = opts['report_script_embeds']
     options[:validation][:report_missing_names] = opts['report_missing_names']
     options[:validation][:report_invalid_tags] = opts['report_invalid_tags']
+
+    options[:typhoeus] = {}
+    options[:typhoeus] = HTMLProofer.parse_json_option('typhoeus_config', opts['typhoeus_config'])
 
     options[:cache] = {}
     options[:cache][:timeframe] = opts['timeframe'] unless opts['timeframe'].nil?

--- a/lib/html-proofer.rb
+++ b/lib/html-proofer.rb
@@ -17,6 +17,26 @@ begin
   require 'pry-byebug'
 rescue LoadError; end
 module HTMLProofer
+  def parse_json_option(option_name, config)
+    raise ArgumentError.new('Must provide an option name in string format.') unless option_name.is_a?(String)
+    raise ArgumentError.new('Must provide an option name in string format.') unless !option_name.strip.empty?
+
+    if config.nil? then {}
+    else
+      raise ArgumentError.new('Must provide a JSON configuration in string format.') unless config.is_a?(String)
+
+    if config.strip.empty? then {}
+    else
+      begin
+        JSON.parse(config)
+      rescue
+        raise ArgumentError.new("Option '" + option_name + "' did not contain valid JSON.")
+      end
+    end
+    end
+  end
+  module_function :parse_json_option
+
   def check_file(file, options = {})
     raise ArgumentError unless file.is_a?(String)
     options[:type] = :file

--- a/spec/html-proofer/parse_json_option_spec.rb
+++ b/spec/html-proofer/parse_json_option_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+require 'html-proofer'
+
+describe 'JSON config parser' do
+  it 'Throws an error when the option name is not a string' do
+    expect { HTMLProofer.parse_json_option(123, '') }.to raise_error(ArgumentError, 'Must provide an option name in string format.')
+  end
+
+  it 'Throws an error when the option name is empty' do
+    expect { HTMLProofer.parse_json_option('', '{}') }.to raise_error(ArgumentError, 'Must provide an option name in string format.')
+  end
+
+  it 'Throws an error when the option name is whitespace' do
+    expect { HTMLProofer.parse_json_option('    ', '{}') }.to raise_error(ArgumentError, 'Must provide an option name in string format.')
+  end
+
+  it 'Throws an error when the json config is not a string' do
+    expect { HTMLProofer.parse_json_option('testName', 123) }.to raise_error(ArgumentError, 'Must provide a JSON configuration in string format.')
+  end
+
+  it 'returns an empty options object when config is nil' do
+    result = HTMLProofer.parse_json_option('testName', nil)
+    expect(result).to eq({})
+  end
+
+  it 'returns an empty options object when config is empty' do
+    result = HTMLProofer.parse_json_option('testName', '')
+    expect(result).to eq({})
+  end
+
+  it 'returns an empty options object when config is whitespace' do
+    result = HTMLProofer.parse_json_option('testName', '    ')
+    expect(result).to eq({})
+  end
+
+  it 'Returns an object representing the json when valid json' do
+    result = HTMLProofer.parse_json_option('testName', '{ "myValue": "hello world!", "numberValue": 123}')
+    expect(result['myValue']).to eq('hello world!')
+    expect(result['numberValue']).to eq(123)
+  end
+
+  it 'Throws an error when the json config is not valid json' do
+    expect { HTMLProofer.parse_json_option('testName', 'abc') }.to raise_error(ArgumentError, "Option 'testName' did not contain valid JSON.")
+  end
+end


### PR DESCRIPTION
Hi all,

First off -- thanks for a great tool! It's useful enough that I [went out of my way to use it for my Jekyll blog](https://seankilleen.com/2018/09/using-wsl-to-make-ruby-play-nice/) recently. 

I noticed that there appear to have been some requests previously to support Typhoeus options from the command-line. I would also find this quite useful, even though we can currently use a ruby script to obtain the same things.

I figured I would take a shot at contributing this feature as an exercise to expand my own ruby capabilities as well as contribute something back that I and others have expressed interest in.

Along the way, I am open to guidance and direction. And I intend to ensure the specs are covered to your satisfaction.

## Suggested Feature Set (as I understand it)

* Enable users to pass `--typhoeus-config CONFIG` with a JSON-formatted config string which we then pass directly in as typhoeus options to the original options object. This is then merged with the defaults.

NOTE: I've examined proposing this with both a command line and a config file option, but am choosing to limit this PR to the cmdline option (will do a follow-up PR for allowing a file if the support is there for adding it).

## Example Usage

`bundle exec htmlproofer --typhoeus-config '{ "timeout": 100 }' ./_site`

## To Do (as I understand it)

* [x] Add `--typhoeus-config` option to mercenary wiring.
* [x] Add `json` as a dependency (to parse the json)
* [x] Config flag description
* [x] Test / run locally
* [x] Update README
* [x] Specs

## Specs

* [x] When JSON parsing is invalid (for file & direct input), show a graceful error
* [x] When no Typhoeus config specified, should be equal to the defaults
* [x] When Typheous config specified, overwrites the defaults.