### PR TITLE
Ignoring sri for pagination rels 

### DIFF
--- a/lib/html-proofer/check/links.rb
+++ b/lib/html-proofer/check/links.rb
@@ -127,7 +127,7 @@ class LinkCheck < ::HTMLProofer::Check
     html.xpath(*xpaths)
   end
 
-  IGNORABE_REL = %(canonical alternate icon manifest apple-touch-icon)
+  IGNORABE_REL = %(canonical alternate next prev previous icon manifest apple-touch-icon)
 
   def check_sri(line, content)
     return if IGNORABE_REL.include?(@link.rel)

--- a/spec/html-proofer/fixtures/links/integrity_and_cors_pagination_rels.html
+++ b/spec/html-proofer/fixtures/links/integrity_and_cors_pagination_rels.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+    <link rel="prev" href="https://github.com" />
+    <link rel="previous" href="https://github.com" />
+    <link rel="next" href="https://github.com" />
+</head>
+<body>
+</body>
+</html>

--- a/spec/html-proofer/links_spec.rb
+++ b/spec/html-proofer/links_spec.rb
@@ -572,6 +572,12 @@ describe 'Links test' do
     expect(proofer.failed_tests).to eq []
   end
 
+  it 'does not check sri for pagination' do
+    file = "#{FIXTURES_DIR}/links/integrity_and_cors_pagination_rels.html"
+    proofer = run_proofer(file, :file, check_sri: true)
+    expect(proofer.failed_tests).to eq []
+  end
+
   it 'does not check local scripts' do
     file = "#{FIXTURES_DIR}/links/local_stylesheet.html"
     proofer = run_proofer(file, :file, check_sri: true)


### PR DESCRIPTION
Will fix #495.
Kinda blowed away my previous fork (https://github.com/gjtorikian/html-proofer/pull/496#issue-228174884) - I wanted to write some checks around pagination links, but I don't have setup to run tests locally (maybe when I'll have normal setup I'll try to do this). 

I've added pagination rels to ignore and writed simple test for it. @Floppy, what do you think?