### PR TITLE
Update gemspec to depend on Nokogiri ~> 1.9.1

### DIFF
--- a/html-proofer.gemspec
+++ b/html-proofer.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'mercenary',       '~> 0.3.2'
-  gem.add_dependency 'nokogiri',        '~> 1.8.1'
+  gem.add_dependency 'nokogiri',        '~> 1.9.1'
   gem.add_dependency 'colorize',        '~> 0.8'
   gem.add_dependency 'typhoeus',        '~> 1.3'
   gem.add_dependency 'yell',            '~> 2.0'


### PR DESCRIPTION
To ensure compatibility with ruby 2.6.0 I updated the nokogiri dependency