### PR TITLE
Let Travis build with ruby 2.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 2.3.6
   - 2.4.3
   - 2.5.0
+  - 2.6.0
 
 git:
   depth: 10
@@ -17,4 +18,4 @@ cache: bundler
 matrix:
   include:
     - script: bundle exec rake rubocop
-      rvm: 2.5.0
+      rvm: 2.6.0


### PR DESCRIPTION
Travis now uses ruby 2.6.0 via rvm for the build environment