### PR TITLE
Making runner return the array of failures to enable file export

### DIFF
--- a/lib/html-proofer/runner.rb
+++ b/lib/html-proofer/runner.rb
@@ -167,9 +167,7 @@ module HTMLProofer
       sorted_failures = SortedIssues.new(@failures, @options[:error_sort], @logger)
 
       sorted_failures.sort_and_report
-      count = @failures.length
-      failure_text = pluralize(count, 'failure', 'failures')
-      raise @logger.colorize :red, "HTML-Proofer found #{failure_text}!"
+      return @failures
     end
   end
 end


### PR DESCRIPTION
If runner returns the data like this, in scripts some variation of the following can be done:

```
def htmlproof path
  options = { :assume_extension => true }
  errorfile = "#{path}/errors.csv"
  if File.directory?(path)
      res = HTMLProofer.check_directory(path, options).run
      `echo '' > #{errorfile}`
      CSV.open(errorfile, "a") do |csv|
        res.each do |row|
          csv << [row]
        end
      end
  end
end
```

The result is a CSV with one failure per row.

It would be really really handy to have the option to export the failures to a CSV!!