### PR TITLE
Don't set blank hash values

### DIFF
--- a/bin/htmlproofer
+++ b/bin/htmlproofer
@@ -77,18 +77,24 @@ Mercenary.program(:htmlproofer) do |p|
     options[:error_sort] = opts['error-sort'].to_sym unless opts['error-sort'].nil?
     options[:log_level] = opts['log_level'].to_sym unless opts['log_level'].nil?
 
-    # FIXME: this is gross
-    options[:validation] = {}
-    options[:validation][:report_script_embeds] = opts['report_script_embeds']
-    options[:validation][:report_missing_names] = opts['report_missing_names']
-    options[:validation][:report_invalid_tags] = opts['report_invalid_tags']
+    options[:validation] = HTMLProofer::Configuration::VALIDATION_DEFAULTS.clone
+    options[:validation][:report_script_embeds] = opts['report_script_embeds'] unless opts['report_script_embeds'] .nil?
+    options[:validation][:report_missing_names] = opts['report_missing_names'] unless opts['report_missing_names'] .nil?
+    options[:validation][:report_invalid_tags] = opts['report_invalid_tags'] unless opts['report_invalid_tags'] .nil?
 
-    options[:typhoeus] = {}
-    options[:typhoeus] = HTMLProofer::Configuration.parse_json_option('typhoeus_config', opts['typhoeus_config'])
+    unless opts['typhoeus_config'].nil?
+      options[:typhoeus] = HTMLProofer::Configuration.parse_json_option('typhoeus_config', opts['typhoeus_config'])
+    end
 
-    options[:cache] = {}
-    options[:cache][:timeframe] = opts['timeframe'] unless opts['timeframe'].nil?
-    options[:cache][:storage_dir] = opts['storage_dir'] unless opts['storage_dir'].nil?
+    unless opts['timeframe'].nil?
+      options[:cache] ||= {}
+      options[:cache][:timeframe] = opts['timeframe'] unless opts['timeframe'].nil?
+    end
+
+    unless opts['storage_dir'].nil?
+      options[:cache] ||= {}
+      options[:cache][:storage_dir] = opts['storage_dir'] unless opts['storage_dir'].nil?
+    end
 
     options[:http_status_ignore] = Array(options[:http_status_ignore]).map(&:to_i)
 

--- a/bin/htmlproofer
+++ b/bin/htmlproofer
@@ -77,10 +77,10 @@ Mercenary.program(:htmlproofer) do |p|
     options[:error_sort] = opts['error-sort'].to_sym unless opts['error-sort'].nil?
     options[:log_level] = opts['log_level'].to_sym unless opts['log_level'].nil?
 
-    options[:validation] = HTMLProofer::Configuration::VALIDATION_DEFAULTS.clone
-    options[:validation][:report_script_embeds] = opts['report_script_embeds'] unless opts['report_script_embeds'] .nil?
-    options[:validation][:report_missing_names] = opts['report_missing_names'] unless opts['report_missing_names'] .nil?
-    options[:validation][:report_invalid_tags] = opts['report_invalid_tags'] unless opts['report_invalid_tags'] .nil?
+    options[:validation] = HTMLProofer::Configuration::VALIDATION_DEFAULTS.dup
+    options[:validation][:report_script_embeds] = opts['report_script_embeds'] unless opts['report_script_embeds'].nil?
+    options[:validation][:report_missing_names] = opts['report_missing_names'] unless opts['report_missing_names'].nil?
+    options[:validation][:report_invalid_tags] = opts['report_invalid_tags'] unless opts['report_invalid_tags'].nil?
 
     unless opts['typhoeus_config'].nil?
       options[:typhoeus] = HTMLProofer::Configuration.parse_json_option('typhoeus_config', opts['typhoeus_config'])


### PR DESCRIPTION
This overwrites the defaults the proofer later attempts to merge in.

Fixes https://github.com/gjtorikian/html-proofer/issues/524.