### PR TITLE
add whitelisted rel types for indieweb links

### DIFF
--- a/lib/html-proofer/check/links.rb
+++ b/lib/html-proofer/check/links.rb
@@ -129,7 +129,7 @@ class LinkCheck < ::HTMLProofer::Check
     html.xpath(*xpaths)
   end
 
-  IGNORABE_REL = %(canonical alternate next prev previous icon manifest apple-touch-icon)
+  IGNORABE_REL = %(canonical alternate next prev previous icon manifest apple-touch-icon me pingback webmention)
 
   def check_sri(line, content)
     return if IGNORABE_REL.include?(@link.rel)

--- a/spec/html-proofer/fixtures/links/link_with_me.html
+++ b/spec/html-proofer/fixtures/links/link_with_me.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+    <link rel="me" href="https://github.com/gjtorikian/html-proofer"/>
+    <link rel="webmention" href="https://webmention.io/username/webmention" />
+    <link rel="pingback" href="https://webmention.io/username/xmlrpc" />
+</head>
+<body>
+</body>
+</html>

--- a/spec/html-proofer/fixtures/vcr_cassettes/links/link_with_me_html_check_sri_true_log_level_error_type_file_.yml
+++ b/spec/html-proofer/fixtures/vcr_cassettes/links/link_with_me_html_check_sri_true_log_level_error_type_file_.yml
@@ -1,0 +1,162 @@
+---
+http_interactions:
+- request:
+    method: head
+    uri: https://github.com/gjtorikian/html-proofer
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/3.11.1; +https://github.com/gjtorikian/html-proofer)
+      Accept:
+      - application/xml,application/xhtml+xml,text/html;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 12 Aug 2019 20:22:47 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Vary:
+      - X-PJAX
+      - Accept-Encoding
+      ETag:
+      - W/"1b2614f953fffcb533c0d7e3c621080c"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Set-Cookie:
+      - has_recent_activity=1; path=/; expires=Mon, 12 Aug 2019 21:22:47 -0000
+      - _octo=GH1.1.548462703.1565641367; domain=.github.com; path=/; expires=Thu,
+        12 Aug 2021 20:22:47 -0000
+      - logged_in=no; domain=.github.com; path=/; expires=Fri, 12 Aug 2039 20:22:47
+        -0000; secure; HttpOnly
+      - _gh_sess=MENDc0pOMlR2cnM2cXJMWmdKQ3lqTStCNjVadFZFOFYrb2dLdUU0SG01NFhHOE1janFPcWJZTkVjL3NCOXYrNHk4b1ZPQmRVNkNqRVV2V2s3TlZRL053TGRxQTlNZUJhbGIzOXRsYnNwcDhJakZNMk5idzJUMUg5eUVxQ0cyZE9zR2dnTUx0VElRY1VQMTBGc0dETHdESVlQY3NYbitHYlNpTlNOdEkydThOcWdJU3g2K0VPV0xHS1FDUkJSMDlGS1VJbVB4UDQzd1BveFoxSU9ZaitJVmw4R2w1VHUraVhtZWZ6S0wrdTh0Zm1OWnN5NS9kQ1F0QXF0WXI1WjZEWVVYRWlsSXJ0eEtONzlnd0JvbElRbjdWU1doMFN3YUxzaXpLQjhPRlo1YWM9LS0ycEsxTDFzTWVxVmc4LzV6T1pvUTB3PT0%3D--c966feb35188f28df48452d9ef5de96cedc325e4;
+        path=/; secure; HttpOnly
+      X-Request-Id:
+      - c3317d62-6ded-44d6-8a7b-79739dc1094f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+      Expect-CT:
+      - max-age=2592000, report-uri="https://api.github.com/_private/browser/errors"
+      Content-Security-Policy:
+      - 'default-src ''none''; base-uri ''self''; block-all-mixed-content; connect-src
+        ''self'' uploads.github.com www.githubstatus.com collector.githubapp.com api.github.com
+        www.google-analytics.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com
+        github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com
+        wss://live.github.com; font-src github.githubassets.com; form-action ''self''
+        github.com gist.github.com; frame-ancestors ''none''; frame-src render.githubusercontent.com;
+        img-src ''self'' data: github.githubassets.com identicons.github.com collector.githubapp.com
+        github-cloud.s3.amazonaws.com *.githubusercontent.com; manifest-src ''self'';
+        media-src ''none''; script-src github.githubassets.com; style-src ''unsafe-inline''
+        github.githubassets.com'
+      X-GitHub-Request-Id:
+      - 9492:3B6B0:30B89C6:4AF5A27:5D51CA97
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://github.com/gjtorikian/html-proofer
+  recorded_at: Mon, 12 Aug 2019 20:22:56 GMT
+- request:
+    method: head
+    uri: https://webmention.io/username/webmention
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/3.11.1; +https://github.com/gjtorikian/html-proofer)
+      Accept:
+      - application/xml,application/xhtml+xml,text/html;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/html;charset=utf-8
+      Content-Length:
+      - '1745'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-XSS-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Aug 2019 20:22:47 GMT
+      X-Powered-By:
+      - Phusion Passenger 5.3.1
+      Server:
+      - nginx/1.14.0 + Phusion Passenger 5.3.1
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://webmention.io/username/webmention
+  recorded_at: Mon, 12 Aug 2019 20:22:56 GMT
+- request:
+    method: head
+    uri: https://webmention.io/username/xmlrpc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/3.11.1; +https://github.com/gjtorikian/html-proofer)
+      Accept:
+      - application/xml,application/xhtml+xml,text/html;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/html;charset=utf-8
+      Content-Length:
+      - '1739'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-XSS-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Aug 2019 20:22:47 GMT
+      X-Powered-By:
+      - Phusion Passenger 5.3.1
+      Server:
+      - nginx/1.14.0 + Phusion Passenger 5.3.1
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://webmention.io/username/xmlrpc
+  recorded_at: Mon, 12 Aug 2019 20:22:56 GMT
+recorded_with: VCR 2.9.3

--- a/spec/html-proofer/links_spec.rb
+++ b/spec/html-proofer/links_spec.rb
@@ -609,6 +609,12 @@ describe 'Links test' do
     expect(proofer.failed_tests).to eq []
   end
 
+  it 'is not checking SRI and CORS for indieweb links with rel "me", "webmention", or "pingback"' do
+    file = "#{FIXTURES_DIR}/links/link_with_me.html"
+    proofer = run_proofer(file, :file, check_sri: true)
+    expect(proofer.failed_tests).to eq []
+  end
+
   it 'can link to external non-unicode hash' do
     file = "#{FIXTURES_DIR}/links/hash_to_unicode_ref.html"
     proofer = run_proofer(file, :file, check_external_hash: true)


### PR DESCRIPTION
Various [indieweb](https://indieweb.org/) capabilities use `link` tags, with `rel`s like `me`, `webmention` and `pingback`. Those don't need SRI or CORS, so this PR whitelists them.

I think there's a better approach to this using a blacklist of rel types rather than a whitelist - after all, the browser will only load certain types. I'll put together another PR for that (update, it's https://github.com/gjtorikian/html-proofer/pull/529), but I wanted to get this simple fix in first in case that one proves more contentious.

If #529 is the preferred solution, this can either be binned or I can update it to just include the new test.