### PR TITLE
Check only stylesheet link rels rather than whitelisting other rels

### DIFF
--- a/lib/html-proofer/check/links.rb
+++ b/lib/html-proofer/check/links.rb
@@ -129,6 +129,8 @@ class LinkCheck < ::HTMLProofer::Check
     html.xpath(*xpaths)
   end
 
+  # Whitelist for affected elements from Subresource Integrity specification
+  # https://w3c.github.io/webappsec-subresource-integrity/#link-element-for-stylesheets
   SRI_REL_TYPES = %(stylesheet)
 
   def check_sri(line, content)

--- a/lib/html-proofer/check/links.rb
+++ b/lib/html-proofer/check/links.rb
@@ -129,10 +129,10 @@ class LinkCheck < ::HTMLProofer::Check
     html.xpath(*xpaths)
   end
 
-  IGNORABE_REL = %(canonical alternate next prev previous icon manifest apple-touch-icon)
+  SRI_REL_TYPES = %(stylesheet)
 
   def check_sri(line, content)
-    return if IGNORABE_REL.include?(@link.rel)
+    return unless SRI_REL_TYPES.include?(@link.rel)
     if !defined?(@link.integrity) && !defined?(@link.crossorigin)
       add_issue("SRI and CORS not provided in: #{@link.src}", line: line, content: content)
     elsif !defined?(@link.integrity)

--- a/spec/html-proofer/fixtures/links/link_with_me.html
+++ b/spec/html-proofer/fixtures/links/link_with_me.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <link rel="me" href="https://github.com/gjtorikian/html-proofer" />
+    <link rel="webmention" href="https://webmention.io/username/webmention" />
+    <link rel="pingback" href="https://webmention.io/username/xmlrpc" />
+  </head>
+  <body></body>
+</html>

--- a/spec/html-proofer/fixtures/vcr_cassettes/links/link_with_me_html_check_sri_true_log_level_error_type_file_.yml
+++ b/spec/html-proofer/fixtures/vcr_cassettes/links/link_with_me_html_check_sri_true_log_level_error_type_file_.yml
@@ -1,0 +1,162 @@
+---
+http_interactions:
+- request:
+    method: head
+    uri: https://github.com/gjtorikian/html-proofer
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/3.11.1; +https://github.com/gjtorikian/html-proofer)
+      Accept:
+      - application/xml,application/xhtml+xml,text/html;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 07 Sep 2019 11:16:44 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Vary:
+      - X-PJAX
+      - Accept-Encoding
+      ETag:
+      - W/"8ae65db5124e3ce28c8d38ba4cba1a6a"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Set-Cookie:
+      - has_recent_activity=1; path=/; expires=Sat, 07 Sep 2019 12:16:43 -0000
+      - _octo=GH1.1.1793523615.1567855004; domain=.github.com; path=/; expires=Tue,
+        07 Sep 2021 11:16:44 -0000
+      - logged_in=no; domain=.github.com; path=/; expires=Wed, 07 Sep 2039 11:16:44
+        -0000; secure; HttpOnly
+      - _gh_sess=b0d4aEE5cjhFSm1SREs2amNzRTg4NUVISVUzVlFCa3gzbUxPVEVZMy82QS8vSG1JUk1lRHI1dXhmMkYrTSt4Q3RpeVh4V1NibS9HNXVmNyt0RldwTWJnc3RTL0dtZkRQQXBFVW10aHFkdkY2VVUxN1N4anducDhOS1hFUkRqdlJHVWR3UmIyTWRRM1JDRFdQNmdZWWtYYlB3ay9HK25rcWhDVVlsRjk3eVZML1Y3YjNDWTNjSVJKQVEyRWZxRE9GWElxTmx2aGFXYi9Ydk1lV0piM0hDR3E4VTRtWWNoWjd3OVlBaGR6WUdaaVg1Q3BQVTBwaEluRi9RNGo1NkpUQW1pV1pmbzZtWkVpWkJTM1FLNzM2aGwyRWR1NXQyVmJFNDJ2Q0tHMzdPajQ9LS1wOU1MdVhjWmtTSFI3d3R5N1dMYTJ3PT0%3D--8e7fc76b0fec0b6318b2480c35f1d51c551d20c3;
+        path=/; secure; HttpOnly
+      X-Request-Id:
+      - 9941fb92-c62e-461b-ab96-47c32bed7d71
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+      Expect-CT:
+      - max-age=2592000, report-uri="https://api.github.com/_private/browser/errors"
+      Content-Security-Policy:
+      - 'default-src ''none''; base-uri ''self''; block-all-mixed-content; connect-src
+        ''self'' uploads.github.com www.githubstatus.com collector.githubapp.com api.github.com
+        www.google-analytics.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com
+        github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com
+        wss://live.github.com; font-src github.githubassets.com; form-action ''self''
+        github.com gist.github.com; frame-ancestors ''none''; frame-src render.githubusercontent.com;
+        img-src ''self'' data: github.githubassets.com identicons.github.com collector.githubapp.com
+        github-cloud.s3.amazonaws.com *.githubusercontent.com; manifest-src ''self'';
+        media-src ''none''; script-src github.githubassets.com; style-src ''unsafe-inline''
+        github.githubassets.com'
+      X-GitHub-Request-Id:
+      - D0A6:35224:C837BA:138300B:5D73919B
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://github.com/gjtorikian/html-proofer
+  recorded_at: Sat, 07 Sep 2019 11:16:44 GMT
+- request:
+    method: head
+    uri: https://webmention.io/username/webmention
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/3.11.1; +https://github.com/gjtorikian/html-proofer)
+      Accept:
+      - application/xml,application/xhtml+xml,text/html;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/html;charset=utf-8
+      Content-Length:
+      - '1745'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-XSS-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Sat, 07 Sep 2019 11:16:44 GMT
+      X-Powered-By:
+      - Phusion Passenger 5.3.1
+      Server:
+      - nginx/1.14.0 + Phusion Passenger 5.3.1
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://webmention.io/username/webmention
+  recorded_at: Sat, 07 Sep 2019 11:16:44 GMT
+- request:
+    method: head
+    uri: https://webmention.io/username/xmlrpc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/3.11.1; +https://github.com/gjtorikian/html-proofer)
+      Accept:
+      - application/xml,application/xhtml+xml,text/html;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/html;charset=utf-8
+      Content-Length:
+      - '1739'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-XSS-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Sat, 07 Sep 2019 11:16:44 GMT
+      X-Powered-By:
+      - Phusion Passenger 5.3.1
+      Server:
+      - nginx/1.14.0 + Phusion Passenger 5.3.1
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://webmention.io/username/xmlrpc
+  recorded_at: Sat, 07 Sep 2019 11:16:44 GMT
+recorded_with: VCR 2.9.3

--- a/spec/html-proofer/fixtures/vcr_cassettes/links/redirected_error_html_log_level_error_type_file_.yml
+++ b/spec/html-proofer/fixtures/vcr_cassettes/links/redirected_error_html_log_level_error_type_file_.yml
@@ -1,0 +1,52 @@
+---
+http_interactions:
+- request:
+    method: head
+    uri: http://asia.cnet.com/blogs/geekonomics/post.htm?id=63009224
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/3.11.1; +https://github.com/gjtorikian/html-proofer)
+      Accept:
+      - application/xml,application/xhtml+xml,text/html;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Last-Modified:
+      - Wed, 15 Aug 2018 23:50:35 GMT
+      ETag:
+      - '"4fb11788e70bf2113c303a1656f55c60"'
+      x-goog-meta-gcsfuse_mtime:
+      - '2016-10-11T15:31:20.13343685Z'
+      Content-Type:
+      - text/html
+      Server:
+      - UploadServer
+      Cache-Control:
+      - private, max-age=0
+      Expires:
+      - Sat, 07 Sep 2019 11:17:38 GMT
+      Date:
+      - Sat, 07 Sep 2019 11:17:38 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - bm_cnet=UB-D60BA1A32D9B1E9CAF58F26A0029BDB9; path=/; secure
+      Vary:
+      - Accept-Encoding, User-Agent
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://www.cnet.com/html/404.html
+  recorded_at: Sat, 07 Sep 2019 11:17:38 GMT
+recorded_with: VCR 2.9.3

--- a/spec/html-proofer/links_spec.rb
+++ b/spec/html-proofer/links_spec.rb
@@ -609,6 +609,12 @@ describe 'Links test' do
     expect(proofer.failed_tests).to eq []
   end
 
+  it 'is not checking SRI and CORS for indieweb links with rel "me", "webmention", or "pingback"' do
+    file = "#{FIXTURES_DIR}/links/link_with_me.html"
+    proofer = run_proofer(file, :file, check_sri: true)
+    expect(proofer.failed_tests).to eq []
+  end
+
   it 'can link to external non-unicode hash' do
     file = "#{FIXTURES_DIR}/links/hash_to_unicode_ref.html"
     proofer = run_proofer(file, :file, check_external_hash: true)


### PR DESCRIPTION
This is the alternative solution for the addition in #528. The SRI spec only applies to `<link rel='stylesheet'>`, so this PR only applies the check to those. This means we don't need an ever-expanding whitelist of rel types, but can easily add more into the check.