### PR TITLE
Update "activesupport" dependency to allow Rails 6

### DIFF
--- a/html-proofer.gemspec
+++ b/html-proofer.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'yell',            '~> 2.0'
   gem.add_dependency 'parallel',        '~> 1.3'
   gem.add_dependency 'addressable',     '~> 2.3'
-  gem.add_dependency 'activesupport',   '>= 4.2', '< 6.0'
+  gem.add_dependency 'activesupport',   '>= 4.2', '< 7.0'
 
   gem.add_development_dependency 'redcarpet'
   gem.add_development_dependency 'rubocop'


### PR DESCRIPTION
With Rails 6.0 released we're encountering some dependency conflicts with html-proofer being tied to active support `< 6.0`.

This PR bumps the upper bound of the ActiveSupport dependency version in `html-proofer.gemspec` from `< 6.0` to `< 7.0`.