### PR TITLE
DO NOT MERGE: uppercase paths failing?

### DIFF
--- a/spec/html-proofer/fixtures/links/link_mismatched_case.html
+++ b/spec/html-proofer/fixtures/links/link_mismatched_case.html
@@ -1,0 +1,1 @@
+<a href="ancHors_iN_pRe.html">Relative to self</a>

--- a/spec/html-proofer/fixtures/links/relative_links.html
+++ b/spec/html-proofer/fixtures/links/relative_links.html
@@ -2,3 +2,4 @@
 <a href="anchors_in_pre.html">Relative to self</a>
 <a href="folder/">Folder relative to self</a>
 <a href="anchors_in_pre.html#anchor">Anchor relative to self</a>
+<a href="topHashInternal.html">Anchor with mixed-case path</a>

--- a/spec/html-proofer/links_spec.rb
+++ b/spec/html-proofer/links_spec.rb
@@ -291,6 +291,12 @@ describe 'Links test' do
     expect(proofer.failed_tests).to eq []
   end
 
+  it 'fails for mismatched path casing' do
+    link_mismatched_case = "#{FIXTURES_DIR}/links/link_mismatched_case.html"
+    proofer = run_proofer(link_mismatched_case, :file)
+    expect(proofer.failed_tests.first).to match('internally linking to ancHors_iN_pRe.html, which does not exist')
+  end
+
   it 'fails for mismatched hash casing' do
     hash_on_another_page = "#{FIXTURES_DIR}/links/hash_mismatched_case.html"
     proofer = run_proofer(hash_on_another_page, :file)


### PR DESCRIPTION
Running against a static site, where HTMLProofer was reporting broken links if the links/files with uppercase characters. Weirdly, this was only happening in some places (CI, on Linux) and not others (my machine, a Mac). I then assumed it must be an issue with case-sensitive vs. insensitive filesystems, but since this test I added passes in (case-sensitive) Linux in TravisCI, I am totally confused about what's going on. Ideas?