### PR TITLE
Update nokogiri to v1.10.4

### DIFF
--- a/html-proofer.gemspec
+++ b/html-proofer.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'mercenary',       '~> 0.3.2'
-  gem.add_dependency 'nokogiri',        '~> 1.9'
+  gem.add_dependency 'nokogiri',        '~> 1.10.4'
   gem.add_dependency 'rainbow',         '~> 3.0'
   gem.add_dependency 'typhoeus',        '~> 1.3'
   gem.add_dependency 'yell',            '~> 2.0'

--- a/lib/html-proofer/version.rb
+++ b/lib/html-proofer/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HTMLProofer
-  VERSION = '3.11.1'.freeze
+  VERSION = '3.12.0'.freeze
 end


### PR DESCRIPTION
Do to a security vulnerability in nokogiri

> CVE-2019-5477 More information
> high severity
> Vulnerable versions: < 1.10.4
> Patched version: 1.10.4
> A command injection vulnerability in Nokogiri v1.10.3 and earlier allows commands to be executed in a subprocess via Ruby's Kernel.open method. Processes are vulnerable only if the undocumented method Nokogiri::CSS::Tokenizer#load_file is being called with unsafe user input as the filename. This vulnerability appears in code generated by the Rexical gem versions v1.0.6 and earlier. Rexical is used by Nokogiri to generate lexical scanner code for parsing CSS queries. The underlying vulnerability was addressed in Rexical v1.0.7 and Nokogiri upgraded to this version of Rexical in Nokogiri v1.10.4.

 this PR updates to that gem to the next safe version, 1.10.4.



I also updated the html-proofer version to 3.12.0