### PR TITLE
Allow accessing list of issues directly

### DIFF
--- a/lib/html-proofer/runner.rb
+++ b/lib/html-proofer/runner.rb
@@ -4,7 +4,7 @@ module HTMLProofer
   class Runner
     include HTMLProofer::Utils
 
-    attr_reader :options, :external_urls
+    attr_reader :options, :external_urls, :failures
 
     def initialize(src, opts = {})
       @src = src

--- a/spec/html-proofer/proofer_spec.rb
+++ b/spec/html-proofer/proofer_spec.rb
@@ -11,6 +11,17 @@ describe HTMLProofer do
     end
   end
 
+  describe '#failures' do
+    it 'is an array of Issue' do
+      broken_link_internal_filepath = "#{FIXTURES_DIR}/links/broken_link_internal.html"
+      proofer = run_proofer(broken_link_internal_filepath, :file)
+      expect(proofer.failures.length).to eq(2)
+      expect(proofer.failures[0].class).to eq(HTMLProofer::Issue)
+      expect(proofer.failures[0].path).to eq('spec/html-proofer/fixtures/links/broken_link_internal.html')
+      expect(proofer.failures[0].desc).to eq('internally linking to ./notreal.html, which does not exist')
+    end
+  end
+
   describe '#files' do
     it 'works for directory that ends with .html' do
       folder = "#{FIXTURES_DIR}/links/_site/folder.html"


### PR DESCRIPTION
👋 This pull request adds a reader for `@failures` so users can access them directly, and use the `Issue` to construct their report if they wish to do so, like what #523 wanted to do. 

In our use case, we mostly want to avoid Proofer from raising a generic `RuntimeError`, and so we will be printing out the errors ourselves. I initially accessed `#failed_tests` for this, but found that we'd want to group results with path. Since `#failed_test` gives us `issue.to_s`, we will have to manually parse it back. Having `#failures` would be more convenient and gives developers flexibility around reporting.

It'd also be good to decouple the checks in `#run` into another method so it can be called without raise/logger. I thought I'd start small for now. Thoughts?

cc @gjtorikian 😬 