### PR TITLE
feat: enable specifying a root folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ The `HTMLProofer` constructor takes an optional hash of additional options:
 | `internal_domains`| An array of Strings containing domains that will be treated as internal urls. | `[]` |
 | `log_level` | Sets the logging level, as determined by [Yell](https://github.com/rudionrails/yell). One of `:debug`, `:info`, `:warn`, `:error`, or `:fatal`. | `:info`
 | `only_4xx` | Only reports errors for links that fall within the 4xx status code range. | `false` |
+| `root_dir` | The absolute path to the directory serving your html-files. Used when running html-proofer on a file, rather than a directory. | "" |
 | `typhoeus_config` | A JSON-formatted string. Parsed using `JSON.parse` and mapped on top of the default configuration values so that they can be overridden. | `{}` |
 | `url_ignore` | An array of Strings or RegExps containing URLs that are safe to ignore. It affects all HTML attributes. Note that non-HTTP(S) URIs are always ignored. | `[]` |
 | `url_swap` | A hash containing key-value pairs of `RegExp => String`. It transforms URLs that match `RegExp` into `String` via `gsub`. | `{}` |

--- a/bin/htmlproofer
+++ b/bin/htmlproofer
@@ -47,6 +47,7 @@ Mercenary.program(:htmlproofer) do |p|
   p.option 'typhoeus_config', '--typhoeus-config CONFIG', String, 'JSON-formatted string of Typhoeus config. Will override the html-proofer defaults.'
   p.option 'url_ignore', '--url-ignore link1,[link2,...]', Array, 'A comma-separated list of Strings or RegExps containing URLs that are safe to ignore. It affects all HTML attributes. Note that non-HTTP(S) URIs are always ignored'
   p.option 'url_swap', '--url-swap re:string,[re:string,...]', Array, 'A comma-separated list containing key-value pairs of `RegExp => String`. It transforms URLs that match `RegExp` into `String` via `gsub`. The escape sequences `\\:` should be used to produce literal `:`s.'
+  p.option 'root_dir', '--root-folder PATH', String, 'The absolute path to the directory serving your html-files. To be used when running html-proofer on a file, rather than a dir. (i.e HTMLProofer.check_file(...))'
 
   p.action do |args, opts|
     args = ['.'] if args.empty?

--- a/bin/htmlproofer
+++ b/bin/htmlproofer
@@ -47,7 +47,7 @@ Mercenary.program(:htmlproofer) do |p|
   p.option 'typhoeus_config', '--typhoeus-config CONFIG', String, 'JSON-formatted string of Typhoeus config. Will override the html-proofer defaults.'
   p.option 'url_ignore', '--url-ignore link1,[link2,...]', Array, 'A comma-separated list of Strings or RegExps containing URLs that are safe to ignore. It affects all HTML attributes. Note that non-HTTP(S) URIs are always ignored'
   p.option 'url_swap', '--url-swap re:string,[re:string,...]', Array, 'A comma-separated list containing key-value pairs of `RegExp => String`. It transforms URLs that match `RegExp` into `String` via `gsub`. The escape sequences `\\:` should be used to produce literal `:`s.'
-  p.option 'root_dir', '--root-folder PATH', String, 'The absolute path to the directory serving your html-files. To be used when running html-proofer on a file, rather than a dir. (i.e HTMLProofer.check_file(...))'
+  p.option 'root_dir', '--root-folder PATH', String, 'The absolute path to the directory serving your html-files. Used when running html-proofer on a file, rather than a directory.'
 
   p.action do |args, opts|
     args = ['.'] if args.empty?

--- a/lib/html-proofer/element.rb
+++ b/lib/html-proofer/element.rb
@@ -164,7 +164,12 @@ module HTMLProofer
       end
 
       if path =~ %r{^/} # path relative to root
-        base = File.directory?(@check.src) ? @check.src : File.dirname(@check.src)
+        if File.directory?(@check.src)
+          base = @check.src
+        else
+          root_dir = @check.options[:root_dir]
+          base = root_dir ? root_dir : File.dirname(@check.src)
+        end
       elsif File.exist?(File.expand_path(path, @check.src)) || File.exist?(File.expand_path(path_dot_ext, @check.src)) # relative links, path is a file
         base = File.dirname @check.path
       elsif File.exist?(File.join(File.dirname(@check.path), path)) || File.exist?(File.join(File.dirname(@check.path), path_dot_ext)) # relative links in nested dir, path is a file

--- a/spec/html-proofer/fixtures/links/working_root_link_internal.html
+++ b/spec/html-proofer/fixtures/links/working_root_link_internal.html
@@ -3,7 +3,7 @@
 <body>
 	<p>
 		Blah blah blah.
-		<a href="/html/html5_tags.html">Not a real link!</a>
+		<a href="/html/html5_tags.html">A real link!</a>
 	</p>
 </body>
 

--- a/spec/html-proofer/fixtures/links/working_root_link_internal.html
+++ b/spec/html-proofer/fixtures/links/working_root_link_internal.html
@@ -1,0 +1,10 @@
+<html>
+
+<body>
+	<p>
+		Blah blah blah.
+		<a href="/html/html5_tags.html">Not a real link!</a>
+	</p>
+</body>
+
+</html>

--- a/spec/html-proofer/links_spec.rb
+++ b/spec/html-proofer/links_spec.rb
@@ -81,7 +81,7 @@ describe 'Links test' do
 
   it 'succeeds for working internal-root-links pointing to other folder' do
     broken_root_link_internal_filepath = "#{FIXTURES_DIR}/links/working_root_link_internal.html"
-    proofer = run_proofer(broken_root_link_internal_filepath, :file, root_dir: '/app/spec/html-proofer/fixtures')
+    proofer = run_proofer(broken_root_link_internal_filepath, :file, root_dir: '/spec/html-proofer/fixtures')
     expect(proofer.failed_tests).to eq []
   end
 

--- a/spec/html-proofer/links_spec.rb
+++ b/spec/html-proofer/links_spec.rb
@@ -79,7 +79,7 @@ describe 'Links test' do
     expect(proofer.failed_tests.first).to match(%r{internally linking to .\/notreal.html, which does not exist})
   end
 
-  it 'succeeds for working internal root links to other folder' do
+  it 'succeeds for working internal-root-links pointing to other folder' do
     broken_root_link_internal_filepath = "#{FIXTURES_DIR}/links/working_root_link_internal.html"
     proofer = run_proofer(broken_root_link_internal_filepath, :file, {:root_dir => "/app/spec/html-proofer/fixtures"})
     expect(proofer.failed_tests).to eq []

--- a/spec/html-proofer/links_spec.rb
+++ b/spec/html-proofer/links_spec.rb
@@ -81,7 +81,7 @@ describe 'Links test' do
 
   it 'succeeds for working internal-root-links pointing to other folder' do
     broken_root_link_internal_filepath = "#{FIXTURES_DIR}/links/working_root_link_internal.html"
-    proofer = run_proofer(broken_root_link_internal_filepath, :file, {:root_dir => "/app/spec/html-proofer/fixtures"})
+    proofer = run_proofer(broken_root_link_internal_filepath, :file, root_dir: '/app/spec/html-proofer/fixtures')
     expect(proofer.failed_tests).to eq []
   end
 

--- a/spec/html-proofer/links_spec.rb
+++ b/spec/html-proofer/links_spec.rb
@@ -79,6 +79,12 @@ describe 'Links test' do
     expect(proofer.failed_tests.first).to match(%r{internally linking to .\/notreal.html, which does not exist})
   end
 
+  it 'succeeds for working internal root links to other folder' do
+    broken_root_link_internal_filepath = "#{FIXTURES_DIR}/links/working_root_link_internal.html"
+    proofer = run_proofer(broken_root_link_internal_filepath, :file, {:root_dir => "/app/spec/html-proofer/fixtures"})
+    expect(proofer.failed_tests).to eq []
+  end
+
   it 'fails for link with no href' do
     missing_link_href_filepath = "#{FIXTURES_DIR}/links/missing_link_href.html"
     proofer = run_proofer(missing_link_href_filepath, :file)

--- a/spec/html-proofer/links_spec.rb
+++ b/spec/html-proofer/links_spec.rb
@@ -81,7 +81,7 @@ describe 'Links test' do
 
   it 'succeeds for working internal-root-links pointing to other folder' do
     broken_root_link_internal_filepath = "#{FIXTURES_DIR}/links/working_root_link_internal.html"
-    proofer = run_proofer(broken_root_link_internal_filepath, :file, root_dir: '/spec/html-proofer/fixtures')
+    proofer = run_proofer(broken_root_link_internal_filepath, :file, root_dir: 'spec/html-proofer/fixtures')
     expect(proofer.failed_tests).to eq []
   end
 


### PR DESCRIPTION
Before: When running .check_file(...) on a file in a non-flat file-hierarchy, it is not possible to specify the root folder from which folder the file is being served. Instead the specified file's folder is assumed as root.
This leads to false positives when refering to a file outside of the specified file's folder.

After: enable specifying a root_dir from where the file is served, when a link begining with slash is found, html-proofer now checks the root_dir for any refered files, so all internal links can be resolved properly.