### PR TITLE
Use "alt attributes" rather than "alt tag"

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ If you generate HTML files, _then this tool might be for you_.
 
 ## Project scope
 
-HTMLProofer is a set of tests to validate your HTML output. These tests check if your image references are legitimate, if they have alt tags, if your internal links are working, and so on. It's intended to be an all-in-one checker for your output.
+HTMLProofer is a set of tests to validate your HTML output. These tests check if your image references are legitimate, if they have alt attributes, if your internal links are working, and so on. It's intended to be an all-in-one checker for your output.
 
 In scope for this project is any well-known and widely-used test for HTML document quality. A major use for this project is continuous integration -- so we must have reliable results. We usually balance correctness over performance. And, if necessary, we should be able to trace this program's detection of HTML errors back to documented best practices or standards, such as W3 specifications.
 
@@ -39,7 +39,7 @@ Below is mostly comprehensive list of checks that HTMLProofer can perform.
 
 `img` elements:
 
-* Whether all your images have alt tags
+* Whether all your images have alt attributes
 * Whether your internal image references are not broken
 * Whether external images are showing
 * Whether your images are HTTP
@@ -288,7 +288,7 @@ The `HTMLProofer` constructor takes an optional hash of additional options:
 | `checks_to_ignore`| An array of Strings indicating which checks you do not want to run | `[]`
 | `directory_index_file` | Sets the file to look for when a link refers to a directory. | `index.html` |
 | `disable_external` | If `true`, does not run the external link checker, which can take a lot of time. | `false` |
-| `empty_alt_ignore` | If `true`, ignores images with empty alt tags. | `false` |
+| `empty_alt_ignore` | If `true`, ignores images with empty alt attributes. | `false` |
 | `enforce_https` | Fails a link if it's not marked as `https`. | `false` |
 | `error_sort` | Defines the sort order for error output. Can be `:path`, `:desc`, or `:status`. | `:path`
 | `extension` | The extension of your HTML files including the dot. | `.html`

--- a/bin/htmlproofer
+++ b/bin/htmlproofer
@@ -29,7 +29,7 @@ Mercenary.program(:htmlproofer) do |p|
   p.option 'check_sri', '--check-sri', 'Check that `<link>` and `<script>` external resources use SRI (default: `false`).'
   p.option 'directory_index_file', '--directory-index-file <filename>', String, 'Sets the file to look for when a link refers to a directory. (default: `index.html`)'
   p.option 'disable_external', '--disable-external', 'If `true`, does not run the external link checker, which can take a lot of time (default: `false`)'
-  p.option 'empty_alt_ignore', '--empty-alt-ignore', 'If `true`, ignores images with empty alt tags'
+  p.option 'empty_alt_ignore', '--empty-alt-ignore', 'If `true`, ignores images with empty alt attributes'
   p.option 'error_sort', '--error-sort <sort>', String, 'Defines the sort order for error output. Can be `:path`, `:desc`, or `:status` (default: `:path`).'
   p.option 'enforce_https', '--enforce-https', 'Fails a link if it\'s not marked as `https` (default: `false`).'
   p.option 'extension', '--extension <ext>', String, 'The extension of your HTML files including the dot. (default: `.html`)'

--- a/html-proofer.gemspec
+++ b/html-proofer.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.authors       = ['Garen Torikian']
   gem.email         = ['gjtorikian@gmail.com']
   gem.description   = %(Test your rendered HTML files to make sure they're accurate.)
-  gem.summary       = %(A set of tests to validate your HTML output. These tests check if your image references are legitimate, if they have alt tags, if your internal links are working, and so on. It's intended to be an all-in-one checker for your documentation output.)
+  gem.summary       = %(A set of tests to validate your HTML output. These tests check if your image references are legitimate, if they have alt attributes, if your internal links are working, and so on. It's intended to be an all-in-one checker for your documentation output.)
   gem.homepage      = 'https://github.com/gjtorikian/html-proofer'
   gem.license       = 'MIT'
   all_files         = `git ls-files -z`.split("\x0")

--- a/spec/html-proofer/images_spec.rb
+++ b/spec/html-proofer/images_spec.rb
@@ -122,13 +122,13 @@ describe 'Images test' do
     expect(proofer.failed_tests).to eq []
   end
 
-  it 'properly ignores missing alt tags when asked' do
+  it 'properly ignores missing alt attributes when asked' do
     ignoreable_links = "#{FIXTURES_DIR}/images/ignorable_alt_via_options.html"
     proofer = run_proofer(ignoreable_links, :file, alt_ignore: [/wikimedia/, 'gpl.png'])
     expect(proofer.failed_tests).to eq []
   end
 
-  it 'properly ignores missing alt tags, but not all URLs, when asked' do
+  it 'properly ignores missing alt attributes, but not all URLs, when asked' do
     ignoreable_links = "#{FIXTURES_DIR}/images/ignore_alt_but_not_link.html"
     proofer = run_proofer(ignoreable_links, :file, alt_ignore: [/.*/])
     expect(proofer.failed_tests.first).to match(/failed: response code 0/)
@@ -153,7 +153,7 @@ describe 'Images test' do
     expect(proofer.failed_tests).to eq []
   end
 
-  it 'skips missing alt tag for images marked as aria-hidden' do
+  it 'skips missing alt attributes for images marked as aria-hidden' do
     src_set_check = "#{FIXTURES_DIR}/images/aria_hidden.html"
     proofer = run_proofer(src_set_check, :file)
     expect(proofer.failed_tests.size).to eq 1
@@ -166,13 +166,13 @@ describe 'Images test' do
     expect(proofer.failed_tests.first).to match(/image gpl.png does not have an alt attribute/)
   end
 
-  it 'fails for images with an alt but missing src or srcset' do
+  it 'fails for images with an alt attribute but missing src or srcset' do
     src_set_missing_alt = "#{FIXTURES_DIR}/images/src_set_missing_image.html"
     proofer = run_proofer(src_set_missing_alt, :file)
     expect(proofer.failed_tests.first).to match(/internal image notreal.png does not exist/)
   end
 
-  it 'properly ignores missing alt tags when asked for srcset' do
+  it 'properly ignores missing alt attributes when asked for srcset' do
     ignoreable_links = "#{FIXTURES_DIR}/images/src_set_ignorable.html"
     proofer = run_proofer(ignoreable_links, :file, alt_ignore: [/wikimedia/, 'gpl.png'])
     expect(proofer.failed_tests).to eq []


### PR DESCRIPTION
In HTML, a tag is used to create an element, like `<img>`. `alt` is an attribute that can be applied to the `<img>` tag, and is not a tag itself.

Applying the correct terminology consistently will benefit users who are new to HTML.