### PR TITLE
Add HTMLProofer::Runner#before_request

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,20 @@ The default value is:
 }
 ```
 
+#### Setting `before-request` callback
+
+You can provide a block to set some logic before an external link is checked. For example, say you want to provide an authentication token every time a GitHub URL is checked. You can do that like this:
+
+```ruby
+proofer = HTMLProofer.check_directory(item, opts)
+proofer.before_request do |request|
+  request.options[:headers]['Authorization'] = "Bearer <TOKEN>" if request.base_url == "https://github.com"
+end
+proofer.run
+```
+
+The `Authorization` header is being set if and only if the `base_url` is `https://github.com`, and it is excluded for all other URLs.
+
 ### Configuring Parallel
 
 [Parallel](https://github.com/grosser/parallel) can be used to speed internal file checks. You can pass in any of its options with the options namespace `:parallel`. For example:

--- a/lib/html-proofer/runner.rb
+++ b/lib/html-proofer/runner.rb
@@ -31,6 +31,7 @@ module HTMLProofer
       end
 
       @failures = []
+      @before_request = []
     end
 
     def run
@@ -117,6 +118,7 @@ module HTMLProofer
 
     def validate_urls
       url_validator = HTMLProofer::UrlValidator.new(@logger, @external_urls, @options)
+      url_validator.before_request = @before_request
       @failures.concat(url_validator.run)
       @external_urls = url_validator.external_urls
     end
@@ -172,6 +174,22 @@ module HTMLProofer
       count = @failures.length
       failure_text = pluralize(count, 'failure', 'failures')
       raise @logger.colorize :fatal, "HTML-Proofer found #{failure_text}!"
+    end
+
+    # Set before_request callback.
+    #
+    # @example Set before_request.
+    #   request.before_request { |request| p "yay" }
+    #
+    # @param [ Block ] block The block to execute.
+    #
+    # @yield [ Typhoeus::Request ]
+    #
+    # @return [ Array<Block> ] All before_request blocks.
+    def before_request(&block)
+      @before_request ||= []
+      @before_request << block if block_given?
+      @before_request
     end
   end
 end

--- a/lib/html-proofer/url_validator.rb
+++ b/lib/html-proofer/url_validator.rb
@@ -10,6 +10,7 @@ module HTMLProofer
     include HTMLProofer::Utils
 
     attr_reader :external_urls
+    attr_writer :before_request
 
     def initialize(logger, external_urls, options)
       @logger = logger
@@ -18,6 +19,7 @@ module HTMLProofer
       @options = options
       @hydra = Typhoeus::Hydra.new(@options[:hydra])
       @cache = Cache.new(@logger, @options[:cache])
+      @before_request = []
     end
 
     def run
@@ -137,6 +139,9 @@ module HTMLProofer
     def queue_request(method, href, filenames)
       opts = @options[:typhoeus].merge(method: method)
       request = Typhoeus::Request.new(href, opts)
+      @before_request.each do |callback|
+        callback.call(request)
+      end
       request.on_complete { |response| response_handler(response, filenames) }
       @hydra.queue request
     end

--- a/spec/html-proofer/runner_spec.rb
+++ b/spec/html-proofer/runner_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe HTMLProofer::Runner do
+  describe '#before_request' do
+    it 'sends authorization header to github.com' do
+      opts = {}
+      url = 'https://github.com'
+      proofer = make_proofer([url], :links, opts)
+      request = nil
+      auth = 'Bearer <TOKEN>'
+      proofer.before_request do |r|
+        r.options[:headers]['Authorization'] = auth if r.base_url == url
+        request = r
+      end
+
+      cassette_name = make_cassette_name("#{FIXTURES_DIR}/links/check_just_once.html", opts)
+      VCR.use_cassette(cassette_name, record: :new_episodes) do
+        capture_stderr { proofer.run }
+        proofer
+      end
+
+      expect(request).to respond_to(:options)
+      expect(request.options).to include(:headers)
+      expect(request.options[:headers]).to include('Authorization' => auth)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the `HTMLProofer::Runner#before_request` method so the `Typhoeus::Request` object can be modified before the request is executed. I'm not happy about the accompanying spec, so any input on how to improve it is welcome.

Fixes #86.