### PR TITLE
Allow usage of Ruby 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.7.2, 2.6.6, 2.5.8, 2.4.10]
+        ruby-version: [3.0.0, 2.7.2, 2.6.6, 2.5.8, 2.4.10]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.0
           bundler-cache: true
       - run: bundle install
       - name: Rubocop

--- a/html-proofer.gemspec
+++ b/html-proofer.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.executables   = all_files.grep(%r{^bin/}) { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(spec)/})
   gem.require_paths = ['lib']
-  gem.required_ruby_version = '>= 2.4.10'
+  gem.required_ruby_version = ['>= 2.4.10', '< 4.0']
 
   gem.add_dependency 'addressable',     '~> 2.3'
   gem.add_dependency 'mercenary',       '~> 0.3'

--- a/html-proofer.gemspec
+++ b/html-proofer.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.executables   = all_files.grep(%r{^bin/}) { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(spec)/})
   gem.require_paths = ['lib']
-  gem.required_ruby_version = '~> 2.4'
+  gem.required_ruby_version = '>= 2.4.10'
 
   gem.add_dependency 'addressable',     '~> 2.3'
   gem.add_dependency 'mercenary',       '~> 0.3'


### PR DESCRIPTION
[Ruby 3.0 has been released](https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/) 🎉 

This PR makes the following changes:

* add Ruby 3.0 to build matrix
* use Ruby 3.0 for linting
* changes `gem.required_ruby_version` to `>= 2.4.10` and `< 4.0`.

~~The changes `gem.required_ruby_version` are TBD. Allowing everything above `2.4.10` (oldest Ruby in build matrix) looked like the simplest solution.~~