### PR TITLE
Proposal: Add an option to provide a data attribute as an image src

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ The `HTMLProofer` constructor takes an optional hash of additional options:
 | `check_opengraph` | Enables the Open Graph checker. | `false` |
 | `check_html` | Enables HTML validation errors from Nokogumbo | `false` |
 | `check_img_http` | Fails an image if it's marked as `http` | `false` |
+| `data_src_attribute` | Sets a data attribute to use as a valid image src, for example `data-src` | "" |
 | `check_sri` | Check that `<link>` and `<script>` external resources use SRI |false |
 | `checks_to_ignore`| An array of Strings indicating which checks you do not want to run | `[]`
 | `directory_index_file` | Sets the file to look for when a link refers to a directory. | `index.html` |

--- a/bin/htmlproofer
+++ b/bin/htmlproofer
@@ -27,6 +27,7 @@ Mercenary.program(:htmlproofer) do |p|
   p.option 'check_img_http', '--check-img-http', 'Fails an image if it\'s marked as `http` (default: `false`).'
   p.option 'check_opengraph', '--check-opengraph', 'Enables the Open Graph checker (default: `false`).'
   p.option 'check_sri', '--check-sri', 'Check that `<link>` and `<script>` external resources use SRI (default: `false`).'
+  p.option 'data_src_attribute', '--data-src-attribute <attribute>', String, 'Sets a data attribute to use as a valid image src, for example `data-src` (default: ``)'
   p.option 'directory_index_file', '--directory-index-file <filename>', String, 'Sets the file to look for when a link refers to a directory. (default: `index.html`)'
   p.option 'disable_external', '--disable-external', 'If `true`, does not run the external link checker, which can take a lot of time (default: `false`)'
   p.option 'empty_alt_ignore', '--empty-alt-ignore', 'If `true`, ignores images with empty alt tags'

--- a/lib/html-proofer/check/images.rb
+++ b/lib/html-proofer/check/images.rb
@@ -31,7 +31,7 @@ class ImageCheck < ::HTMLProofer::Check
 
       # does the image exist?
       if missing_src?
-        add_issue('image has no src or srcset attribute', line: line, content: content)
+        add_issue('image has no src, srcset, or data src attribute', line: line, content: content)
       elsif @img.remote?
         add_to_external_urls(@img.url)
       elsif !@img.exists?

--- a/lib/html-proofer/configuration.rb
+++ b/lib/html-proofer/configuration.rb
@@ -16,6 +16,7 @@ module HTMLProofer
       check_opengraph: false,
       checks_to_ignore: [],
       check_sri: false,
+      data_src_attribute: '',
       directory_index_file: 'index.html',
       disable_external: false,
       empty_alt_ignore: false,

--- a/lib/html-proofer/element.rb
+++ b/lib/html-proofer/element.rb
@@ -16,10 +16,11 @@ module HTMLProofer
       # Construct readable ivars for every element
       begin
         obj.attributes.each_pair do |attribute, value|
-          name = attribute.tr('-:.;@', '_').to_s.to_sym
-          if data_src_attribute? && data_src_attribute == attribute
-            name = :datasrc
-          end
+          name = if data_src_attribute? && data_src_attribute == attribute
+                   :datasrc
+                 else
+                   attribute.tr('-:.;@', '_').to_s.to_sym
+                 end
           (class << self; self; end).send(:attr_reader, name)
           instance_variable_set("@#{name}", value.value)
         end
@@ -152,7 +153,7 @@ module HTMLProofer
     end
 
     def data_src_attribute?
-      ! @check.options[:data_src_attribute].empty?
+      !@check.options[:data_src_attribute].empty?
     end
 
     def data_src_attribute

--- a/lib/html-proofer/element.rb
+++ b/lib/html-proofer/element.rb
@@ -64,6 +64,8 @@ module HTMLProofer
 
       if defined?(@datasrc)
         @datasrc.insert(0, 'http:') if %r{^//}.match?(@datasrc)
+      else
+        @datasrc = nil
       end
     end
 

--- a/spec/html-proofer/fixtures/cache/.runner.log
+++ b/spec/html-proofer/fixtures/cache/.runner.log
@@ -1,1 +1,1 @@
-{"https://www.github.com":{"time":"2021-03-04 07:54:18 -0500","filenames":["spec/html-proofer/fixtures/links/_site/folder.html/index.html"],"status":200,"message":""}}
+{"https://www.github.com":{"time":"2021-03-19 21:10:45 -0400","filenames":["spec/html-proofer/fixtures/links/_site/folder.html/index.html"],"status":200,"message":""}}

--- a/spec/html-proofer/fixtures/images/data_src_attribute.html
+++ b/spec/html-proofer/fixtures/images/data_src_attribute.html
@@ -1,0 +1,9 @@
+<html>
+
+<body>
+
+  <p>Blah blah blah. <img alt="An http image" data-src="gpl.png" /> </p>
+
+</body>
+
+</html>

--- a/spec/html-proofer/images_spec.rb
+++ b/spec/html-proofer/images_spec.rb
@@ -61,7 +61,7 @@ describe 'Images test' do
   it 'fails for image with no src' do
     image_src_filepath = "#{FIXTURES_DIR}/images/missing_image_src.html"
     proofer = run_proofer(image_src_filepath, :file)
-    expect(proofer.failed_tests.first).to match(/image has no src or srcset attribute/)
+    expect(proofer.failed_tests.first).to match(/image has no src, srcset, or data src attribute/)
   end
 
   it 'fails for image with default mac filename' do
@@ -150,6 +150,12 @@ describe 'Images test' do
   it 'works for images with a srcset' do
     src_set_check = "#{FIXTURES_DIR}/images/src_set_check.html"
     proofer = run_proofer(src_set_check, :file)
+    expect(proofer.failed_tests).to eq []
+  end
+
+  it 'works for images with a data attribute src' do
+    custom_data_src_check = "#{FIXTURES_DIR}/images/data_src_attribute.html"
+    proofer = run_proofer(custom_data_src_check, :file, data_src_attribute: 'data-src')
     expect(proofer.failed_tests).to eq []
   end
 


### PR DESCRIPTION
Hey there @gjtorikian! I'm using `html-proofer` in a project that uses `data-src` attributes on images to load optimized versions after page load. We're specifically using [UIKit](https://getuikit.com/docs/image#usage) to accomplish this, but it's also a common pattern in other libraries that manipulate image src on pageload.

In some cases there are both `src` attributes and `data-src` together. But we're also using a pattern that applies the default image to the background, so some image tags have `data-src` attributes but not `src` attributes when the initial HTML is rendered - which results in invalid image src errors. Rather than ignoring all of these images, my goal was to still have validation of the URLs, so I created a fork with a proof of concept for adding data attributes as valid image src urls via configuration.

I've really only tested the happy path here, and I'm not convinced the naming conventions are super clear, but thought I'd open this PR to see if you're interested in this feature making it's way into the core library.