### PR TITLE
Replace Nokogumbo with Nokogiri

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Below is mostly comprehensive list of checks that HTMLProofer can perform.
 
 ### HTML
 
-* Whether your HTML markup is valid. This is done via [Nokogumbo](https://github.com/rubys/nokogumbo) to validate well-formed HTML5 markup.
+* Whether your HTML markup is valid. This is done via [Nokogiri](https://nokogiri.org/) to validate well-formed HTML5 markup.
 
 ## Usage
 

--- a/html-proofer.gemspec
+++ b/html-proofer.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'addressable',     '~> 2.3'
   gem.add_dependency 'mercenary',       '~> 0.3'
-  gem.add_dependency 'nokogumbo',       '~> 2.0'
+  gem.add_dependency 'nokogiri',        '~> 1.12'
   gem.add_dependency 'parallel',        '~> 1.3'
   gem.add_dependency 'rainbow',         '~> 3.0'
   gem.add_dependency 'typhoeus',        '~> 1.3'

--- a/lib/html-proofer/utils.rb
+++ b/lib/html-proofer/utils.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'nokogumbo'
+require 'nokogiri'
 
 module HTMLProofer
   module Utils


### PR DESCRIPTION
Nokogiri 1.12 merged all of the code from Nokogumbo and thus Nokogumbo
is no longer needed.