### PR TITLE
Run htmlproofer and precede it with the correct ruby binary

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -78,7 +78,7 @@ def capture_proofer_http(item, type, opts = {})
 end
 
 def make_bin(args)
-  stdout, stderr = Open3.capture3("bin/htmlproofer #{args}")
+  stdout, stderr = Open3.capture3("#{RbConfig.ruby} bin/htmlproofer #{args}")
   "#{stdout}\n#{stderr}".encode('UTF-8', invalid: :replace, undef: :replace)
 end
 


### PR DESCRIPTION
We are in the midst of the transition from Ruby 2.7 to 3.0 and run the tests with both versions. But the shebang line in `bin/htmlproofer` will always resolve to the default version, not to the used Ruby version. This small patch makes sure to run it with the Ruby binary belonging to the used environment.