### PR TITLE
Add typhoeus-config user agent and cookies snippets to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,6 +543,28 @@ HTMLProofer.check_directory("out/", {
 }}).run
 ```
 
+Alternatively, you can specifify these options on the commandline with:
+
+```bash
+htmlproofer --typhoeus-config='{"headers":{"User-Agent":"Mozilla/5.0 (compatible; My New User-Agent)"}}'
+```
+
+### Cookies
+
+Sometimes links fail because they don't have access to cookies. To fix this you can create a .cookies file using the following snippets:
+
+``` ruby
+HTMLProofer.check_directory("out/", {
+  :typhoeus => {
+    :cookiefile => ".cookies",
+    :cookiejar => ".cookies"
+}}).run
+```
+
+```bash
+htmlproofer --typhoeus-config='{"cookiefile":".cookies","cookiejar":".cookies"}'
+```
+
 ### Regular expressions
 
 To exclude urls using regular expressions, include them between forward slashes and don't quote them:


### PR DESCRIPTION
I think this might resolve the issues seen in #581 (which is already closed) by allowing cookies in typhoeus.

Adds some snippets to the README to show how to specify a cookie file (from ruby (untested) and the command line) and user agent (from the command line).

I spent some time figuring this out and thought that the information should be in the README for future users. Let me know what you think.