### PR TITLE
Fix internal cache metadata check

### DIFF
--- a/lib/html_proofer/runner.rb
+++ b/lib/html_proofer/runner.rb
@@ -97,40 +97,38 @@ module HTMLProofer
     # Walks over each implemented check and runs them on the files, in parallel.
     def process_files
       if @options[:parallel][:enable]
-        Parallel.map(files, @options[:parallel]) { |path| load_file(path) }
+        Parallel.map(files, @options[:parallel]) { |file| load_file(file[:path], file[:source]) }
       else
-        files.map { |path| load_file(path) }
+        files.map do |file|
+          load_file(file[:path], file[:source])
+        end
       end
     end
 
-    def load_file(path)
+    def load_file(path, source)
       @html = create_nokogiri(path)
-      check_parsed(path)
+      check_parsed(path, source)
     end
 
     # Collects any external URLs found in a directory of files. Also collectes
     # every failed test from process_files.
-    def check_parsed(path)
+    def check_parsed(path, source)
       result = { internal_urls: {}, external_urls: {}, failures: [] }
 
-      @source = [@source] if @type == :file
+      checks.each do |klass|
+        @current_source = source
+        @current_path = path
 
-      @source.each do |current_source|
-        checks.each do |klass|
-          @current_source = current_source
-          @current_path = path
+        check = Object.const_get(klass).new(self, @html)
+        @logger.log :debug, "Running #{check.short_name} in #{path}"
 
-          check = Object.const_get(klass).new(self, @html)
-          @logger.log :debug, "Running #{check.short_name} in #{path}"
+        @current_check = check
 
-          @current_check = check
+        check.run
 
-          check.run
-
-          result[:external_urls].merge!(check.external_urls) { |_key, old, current| old.concat(current) }
-          result[:internal_urls].merge!(check.internal_urls) { |_key, old, current| old.concat(current) }
-          result[:failures].concat(check.failures)
-        end
+        result[:external_urls].merge!(check.external_urls) { |_key, old, current| old.concat(current) }
+        result[:internal_urls].merge!(check.internal_urls) { |_key, old, current| old.concat(current) }
+        result[:failures].concat(check.failures)
       end
       result
     end
@@ -150,10 +148,10 @@ module HTMLProofer
       @files ||= if @type == :directory
                    @source.map do |src|
                      pattern = File.join(src, '**', "*{#{@options[:extensions].join(',')}}")
-                     Dir.glob(pattern).select { |f| File.file?(f) && !ignore_file?(f) }
+                     Dir.glob(pattern).select { |f| File.file?(f) && !ignore_file?(f) }.map { |f| { source: src, path: f } }
                    end.flatten
-                 elsif @type == :file &&  @options[:extensions].include?(File.extname(@source))
-                   [@source].reject { |f| ignore_file?(f) }
+                 elsif @type == :file && @options[:extensions].include?(File.extname(@source))
+                   [@source].reject { |f| ignore_file?(f) }.map { |f| { source: f, path: f } }
                  else
                    []
                  end

--- a/lib/html_proofer/runner.rb
+++ b/lib/html_proofer/runner.rb
@@ -127,8 +127,8 @@ module HTMLProofer
 
           check.run
 
-          result[:external_urls].merge!(check.external_urls)
-          result[:internal_urls].merge!(check.internal_urls)
+          result[:external_urls].merge!(check.external_urls) { |_key, old, current| old.concat(current) }
+          result[:internal_urls].merge!(check.internal_urls) { |_key, old, current| old.concat(current) }
           result[:failures].concat(check.failures)
         end
       end

--- a/spec/html-proofer/fixtures/links/multiple_links.html
+++ b/spec/html-proofer/fixtures/links/multiple_links.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Example</title>
+  </head>
+  <body>
+    <a href="https://missing.png">The amazing gjtorikian</a>
+    <img alt="missing same as link" src="https://missing.png" />
+    <img alt="missing only as img" src="https://another.png" />
+    <a href="/pdfs.html">Existing internal link</a>
+  </body>
+</html>

--- a/spec/html-proofer/fixtures/vcr_cassettes/links/multiple_links_html_log_level_error_type_file_.yml
+++ b/spec/html-proofer/fixtures/vcr_cassettes/links/multiple_links_html_log_level_error_type_file_.yml
@@ -1,0 +1,53 @@
+---
+http_interactions:
+- request:
+    method: head
+    uri: https://another.png
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/4.0.0.rc3; +https://github.com/gjtorikian/html-proofer)
+      Accept:
+      - application/xml,application/xhtml+xml,text/html;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+      Expect:
+      - ''
+  response:
+    status:
+      code: 0
+      message:
+    headers: {}
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    http_version:
+    adapter_metadata:
+      effective_url: https://another.png/
+  recorded_at: Sun, 09 Jan 2022 17:09:12 GMT
+- request:
+    method: head
+    uri: https://missing.png
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; HTML Proofer/4.0.0.rc3; +https://github.com/gjtorikian/html-proofer)
+      Accept:
+      - application/xml,application/xhtml+xml,text/html;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+      Expect:
+      - ''
+  response:
+    status:
+      code: 0
+      message:
+    headers: {}
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    http_version:
+    adapter_metadata:
+      effective_url: https://missing.png/
+  recorded_at: Sun, 09 Jan 2022 17:09:12 GMT
+recorded_with: VCR 2.9.3

--- a/spec/html-proofer/links_spec.rb
+++ b/spec/html-proofer/links_spec.rb
@@ -200,6 +200,12 @@ describe 'Links test' do
     expect(proofer.failed_checks.first.description).to match(/internally linking to #anadaasdadsadschor; the file exists, but the hash 'anadaasdadsadschor' does not/)
   end
 
+  it 'finds the same broken link multiple times' do
+    multiple_problems = File.join(FIXTURES_DIR, 'links', 'multiple_links.html')
+    proofer = run_proofer(multiple_problems, :file)
+    expect(proofer.failed_checks.length).to eq(3)
+  end
+
   it 'ignores valid mailto links' do
     ignorable_links = File.join(FIXTURES_DIR, 'links', 'mailto_link.html')
     proofer = run_proofer(ignorable_links, :file)
@@ -671,9 +677,16 @@ describe 'Links test' do
   end
 
   it 'works for a direct link through directory' do
-    file = File.join(FIXTURES_DIR, 'links', 'internals')
-    proofer = run_proofer(file, :directory)
+    dir = File.join(FIXTURES_DIR, 'links', 'internals')
+    proofer = run_proofer(dir, :directory)
     expect(proofer.failed_checks).to eq []
+  end
+
+  it 'knows how to find internal link with additional sources' do
+    empty_dir = File.join(FIXTURES_DIR, 'links', 'same_name_as_dir')
+    valid_dir = File.join(FIXTURES_DIR, 'links', 'internals')
+    proofer = run_proofer([valid_dir,empty_dir], :directories)
+    expect(proofer.failed_checks.length).to eq(0)
   end
 
   it 'reports linked internal through directory' do

--- a/spec/html-proofer/links_spec.rb
+++ b/spec/html-proofer/links_spec.rb
@@ -685,7 +685,7 @@ describe 'Links test' do
   it 'knows how to find internal link with additional sources' do
     empty_dir = File.join(FIXTURES_DIR, 'links', 'same_name_as_dir')
     valid_dir = File.join(FIXTURES_DIR, 'links', 'internals')
-    proofer = run_proofer([valid_dir,empty_dir], :directories)
+    proofer = run_proofer([valid_dir, empty_dir], :directories)
     expect(proofer.failed_checks.length).to eq(0)
   end
 

--- a/spec/html-proofer/proofer_spec.rb
+++ b/spec/html-proofer/proofer_spec.rb
@@ -19,7 +19,7 @@ describe HTMLProofer do
     it 'works for directory that ends with .html' do
       folder = File.join(FIXTURES_DIR, 'links', '_site/folder.html')
       proofer = HTMLProofer.check_directory(folder)
-      expect(proofer.files).to eq(["#{folder}/index.html"])
+      expect(proofer.files).to eq([{ source: folder, path: "#{folder}/index.html" }])
     end
   end
 


### PR DESCRIPTION
Fixes #695

* Unit test revealing issue #695
* Fix logic for checking cached failures and managing new url metadata