### PR TITLE
Use <path>:<line> in the CLI reporter

### DIFF
--- a/lib/html_proofer/reporter/cli.rb
+++ b/lib/html_proofer/reporter/cli.rb
@@ -8,11 +8,11 @@ module HTMLProofer
           str = ["For the #{check_name} check, the following failures were found:\n"]
 
           failures.each do |failure|
-            path_str = blank?(failure.path) ? "" : "In #{failure.path}"
+            path_str = blank?(failure.path) ? "" : "At #{failure.path}"
 
-            line_str = failure.line.nil? ? "" : " (line #{failure.line})"
+            line_str = failure.line.nil? ? "" : ":#{failure.line}"
 
-            path_and_line = [path_str, line_str].join
+            path_and_line = "#{path_str}#{line_str}"
             path_and_line = blank?(path_and_line) ? "" : "* #{path_and_line}:\n\n"
 
             status_str = failure.status.nil? ? "" : " (status code #{failure.status})"

--- a/spec/html-proofer/check_spec.rb
+++ b/spec/html-proofer/check_spec.rb
@@ -26,7 +26,7 @@ describe HTMLProofer::Reporter do
     VCR.use_cassette(cassette_name, record: :new_episodes) do
       proofer = make_proofer(file, :file, { checks: ["MailToOctocat"] })
       output = capture_stderr { proofer.run }
-      expect(output).to(include("In #{file} (line 1)"))
+      expect(output).to(include("At #{file}:1"))
     end
   end
 end

--- a/spec/html-proofer/cli_reporter_spec.rb
+++ b/spec/html-proofer/cli_reporter_spec.rb
@@ -11,63 +11,63 @@ describe HTMLProofer::Reporter::Cli do
       msg = <<~MSG
         For the Favicon check, the following failures were found:
 
-        * In spec/html-proofer/fixtures/sorting/kitchen_sinkish.html:
+        * At spec/html-proofer/fixtures/sorting/kitchen_sinkish.html:
 
           no favicon provided
 
         For the Images check, the following failures were found:
 
-        * In spec/html-proofer/fixtures/sorting/kitchen_sinkish.html (line 5):
+        * At spec/html-proofer/fixtures/sorting/kitchen_sinkish.html:5:
 
           internal image ./gpl.png does not exist
 
-        * In spec/html-proofer/fixtures/sorting/kitchen_sinkish.html (line 5):
+        * At spec/html-proofer/fixtures/sorting/kitchen_sinkish.html:5:
 
           image ./gpl.png does not have an alt attribute
 
-        * In spec/html-proofer/fixtures/sorting/kitchen_sinkish.html (line 6):
+        * At spec/html-proofer/fixtures/sorting/kitchen_sinkish.html:6:
 
           internal image NOT_AN_IMAGE does not exist
 
-        * In spec/html-proofer/fixtures/sorting/kitchen_sinkish.html (line 10):
+        * At spec/html-proofer/fixtures/sorting/kitchen_sinkish.html:10:
 
           internal image gpl.png does not exist
 
-        * In spec/html-proofer/fixtures/sorting/kitchen_sinkish.html (line 10):
+        * At spec/html-proofer/fixtures/sorting/kitchen_sinkish.html:10:
 
           image gpl.png does not have an alt attribute
 
-        * In spec/html-proofer/fixtures/sorting/kitchen_sinkish.html (line 12):
+        * At spec/html-proofer/fixtures/sorting/kitchen_sinkish.html:12:
 
           image has a terrible filename (./Screen Shot 2012-08-09 at 7.51.18 AM.png)
 
-        * In spec/html-proofer/fixtures/sorting/kitchen_sinkish.html (line 12):
+        * At spec/html-proofer/fixtures/sorting/kitchen_sinkish.html:12:
 
           internal image ./Screen Shot 2012-08-09 at 7.51.18 AM.png does not exist
 
         For the Links check, the following failures were found:
 
-        * In spec/html-proofer/fixtures/sorting/kitchen_sinkish.html (line 8):
+        * At spec/html-proofer/fixtures/sorting/kitchen_sinkish.html:8:
 
           tel: contains no phone number
 
         For the Links > External check, the following failures were found:
 
-        * In spec/html-proofer/fixtures/sorting/kitchen_sinkish.html (line 14):
+        * At spec/html-proofer/fixtures/sorting/kitchen_sinkish.html:14:
 
           External link https://upload.wikimedia.org/wikipedia/en/thumb/not_here.png failed (status code 404)
 
-        * In spec/html-proofer/fixtures/sorting/kitchen_sinkish.html (line 19):
+        * At spec/html-proofer/fixtures/sorting/kitchen_sinkish.html:19:
 
           External link https://upload.wikimedia.org/wikipedia/en/thumb/fooooof.png failed (status code 404)
 
-        * In spec/html-proofer/fixtures/sorting/kitchen_sinkish.html (line 26):
+        * At spec/html-proofer/fixtures/sorting/kitchen_sinkish.html:26:
 
           External link https://help.github.com/changing-author-info/ failed (status code 404)
 
         For the Links > Internal check, the following failures were found:
 
-        * In spec/html-proofer/fixtures/sorting/kitchen_sinkish.html (line 24):
+        * At spec/html-proofer/fixtures/sorting/kitchen_sinkish.html:24:
 
           internally linking to nowhere.fooof, which does not exist
 


### PR DESCRIPTION
* This is recognized by many terminals / IDEs, and allows reaching the line in the file from the reported error message.