### PR TITLE
Srcsets - better handling of multiple srcsets

### DIFF
--- a/lib/html_proofer/check/images.rb
+++ b/lib/html_proofer/check/images.rb
@@ -25,7 +25,7 @@ module HTMLProofer
               content: @img.content)
           elsif @img.multiple_srcsets? || @img.multiple_sizes?
             @img.srcsets_wo_sizes.each do |srcset|
-              srcset_url = HTMLProofer::Attribute::Url.new(@runner, srcset, base_url: @img.base_url)
+              srcset_url = HTMLProofer::Attribute::Url.new(@runner, srcset, base_url: @img.base_url, extract_size: true)
 
               if srcset_url.remote?
                 add_to_external_urls(srcset_url.url, @img.line)

--- a/lib/html_proofer/check/images.rb
+++ b/lib/html_proofer/check/images.rb
@@ -23,19 +23,9 @@ module HTMLProofer
           elsif !@img.url.exists? && !@img.multiple_srcsets? && !@img.multiple_sizes?
             add_failure("internal image #{@img.url.raw_attribute} does not exist", line: @img.line,
               content: @img.content)
-          elsif @img.multiple_srcsets?
-            @img.srcsets.each do |srcset|
-              srcset_url = HTMLProofer::Attribute::Url.new(@runner, srcset, base_url: @img.base_url, extract_size: true)
-
-              if srcset_url.remote?
-                add_to_external_urls(srcset_url.url, @img.line)
-              elsif !srcset_url.exists?
-                add_failure("internal image #{srcset} does not exist", line: @img.line, content: @img.content)
-              end
-            end
-          elsif @img.multiple_sizes?
+          elsif @img.multiple_srcsets? || @img.multiple_sizes?
             @img.srcsets_wo_sizes.each do |srcset|
-              srcset_url = HTMLProofer::Attribute::Url.new(@runner, srcset, base_url: @img.base_url, extract_size: true)
+              srcset_url = HTMLProofer::Attribute::Url.new(@runner, srcset, base_url: @img.base_url)
 
               if srcset_url.remote?
                 add_to_external_urls(srcset_url.url, @img.line)

--- a/spec/html-proofer/fixtures/images/multiple_srcset-pixel-density.html
+++ b/spec/html-proofer/fixtures/images/multiple_srcset-pixel-density.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <img srcset="1.webp 1.5x, gpl.png 200w" alt="test" width="100" height="150" />
+  </body>
+</html>

--- a/spec/html-proofer/images_spec.rb
+++ b/spec/html-proofer/images_spec.rb
@@ -233,7 +233,7 @@ describe "Images test" do
   it "supports multiple srcsets when fails" do
     relative_images = File.join(FIXTURES_DIR, "images", "multiple_srcset_failure.html")
     proofer = run_proofer(relative_images, :file)
-    expect(proofer.failed_checks.first.description).to(eq("internal image /uploads/150-marie-lloyd.jpg 1.5x does not exist"))
+    expect(proofer.failed_checks.first.description).to(eq("internal image /uploads/150-marie-lloyd.jpg does not exist"))
   end
 
   it "works for images with a swapped data attribute src" do
@@ -258,6 +258,12 @@ describe "Images test" do
     custom_data_src_check = "#{FIXTURES_DIR}/images/srcset-pixel-density_broken.html"
     proofer = run_proofer(custom_data_src_check, :file)
     expect(proofer.failed_checks.first.description).to(match(/foo.webp does not exist/))
+  end
+
+  it "works for images with multiple srcsets and pixel densities" do
+    custom_data_src_check = "#{FIXTURES_DIR}/images/multiple_srcset-pixel-density.html"
+    proofer = run_proofer(custom_data_src_check, :file)
+    expect(proofer.failed_checks).to(eq([]))
   end
 
   it "works for various webp images" do


### PR DESCRIPTION
The previous fix to #724 didn't handle this situation:

`srcset="test.webp 1.5x, test2.webp 2x"`

This PR should fix this, add a new test case, and hopefully remove some code duplication as a nice bonus.