### PR TITLE
Switch 'source' elements to use image check code path

### DIFF
--- a/lib/html_proofer/check/images.rb
+++ b/lib/html_proofer/check/images.rb
@@ -6,7 +6,7 @@ module HTMLProofer
       SCREEN_SHOT_REGEX = /Screen(?: |%20)Shot(?: |%20)\d+-\d+-\d+(?: |%20)at(?: |%20)\d+.\d+.\d+/.freeze
 
       def run
-        @html.css("img").each do |node|
+        @html.css("img, source").each do |node|
           @img = create_element(node)
 
           next if @img.ignore?
@@ -35,7 +35,8 @@ module HTMLProofer
             end
           end
 
-          unless ignore_element?
+          # if this is an img element, check that the alt attribute is present
+          if @img.img_tag? && !ignore_element?
             if missing_alt_tag? && !ignore_missing_alt?
               add_failure("image #{@img.url.raw_attribute} does not have an alt attribute", line: @img.line,
                 content: @img.content)

--- a/lib/html_proofer/check/links.rb
+++ b/lib/html_proofer/check/links.rb
@@ -4,7 +4,7 @@ module HTMLProofer
   class Check
     class Links < HTMLProofer::Check
       def run
-        @html.css("a, link, source").each do |node|
+        @html.css("a, link").each do |node|
           @link = create_element(node)
 
           next if @link.ignore?

--- a/spec/html-proofer/fixtures/images/src_set_check_pass.html
+++ b/spec/html-proofer/fixtures/images/src_set_check_pass.html
@@ -3,5 +3,5 @@
     <source srcset="webp/user_760.webp" media="(min-width: 1000px)">
     <source srcset="webp/user_400.webp" media="(min-width: 800px)">
     <!--[if IE 9]></video><![endif]-->
-    <img srcset="gpl.png">
+    <img src="gpl.png" alt="Working">
 </picture>

--- a/spec/html-proofer/fixtures/images/src_set_missing_image.html
+++ b/spec/html-proofer/fixtures/images/src_set_missing_image.html
@@ -1,7 +1,7 @@
 <picture>
   <!--[if IE 9]><video style="display: none;"><![endif]-->
-  <source srcset="examples/images/extralarge.jpg" media="(min-width: 1000px)" />
-  <source srcset="examples/images/large.jpg" media="(min-width: 800px)" />
+  <source srcset="webp/user_760.webp" media="(min-width: 1000px)" />
+  <source srcset="webp/user_400.webp" media="(min-width: 800px)" />
   <!--[if IE 9]></video><![endif]-->
   <img alt="Missing image" />
 </picture>

--- a/spec/html-proofer/fixtures/images/srcset_picture_pixel-density.html
+++ b/spec/html-proofer/fixtures/images/srcset_picture_pixel-density.html
@@ -1,0 +1,6 @@
+<picture>
+    <!--[if IE 9]><video style="display: none;"><![endif]-->
+    <source srcset="webp/user_760.webp 1000px, webp/user_400.webp 800px">
+    <!--[if IE 9]></video><![endif]-->
+    <img srcset="gpl.png" alt="test">
+</picture>

--- a/spec/html-proofer/fixtures/images/srcset_picture_pixel-density_broken.html
+++ b/spec/html-proofer/fixtures/images/srcset_picture_pixel-density_broken.html
@@ -1,0 +1,6 @@
+<picture>
+  <!--[if IE 9]><video style="display: none;"><![endif]-->
+  <source srcset="foo.webp 1000px, foo2.webp 800px">
+  <!--[if IE 9]></video><![endif]-->
+  <img srcset="gpl.png" alt="test">
+</picture>

--- a/spec/html-proofer/images_spec.rb
+++ b/spec/html-proofer/images_spec.rb
@@ -164,7 +164,13 @@ describe "Images test" do
     expect(proofer.failed_checks).to(eq([]))
   end
 
-  it "works for images with a srcset" do
+  it "passes for images with a srcset pointing to existing files" do
+    src_set_check = File.join(FIXTURES_DIR, "images", "src_set_check_pass.html")
+    proofer = run_proofer(src_set_check, :file)
+    expect(proofer.failed_checks).to(eq([]))
+  end
+
+  it "fails for images with a srcset pointing to missing files" do
     src_set_check = File.join(FIXTURES_DIR, "images", "src_set_check.html")
     proofer = run_proofer(src_set_check, :file)
     expect(proofer.failed_checks.length).to(eq(2))
@@ -264,6 +270,18 @@ describe "Images test" do
     custom_data_src_check = "#{FIXTURES_DIR}/images/multiple_srcset-pixel-density.html"
     proofer = run_proofer(custom_data_src_check, :file)
     expect(proofer.failed_checks).to(eq([]))
+  end
+
+  it "works for picture elements with multiple srcsets and pixel densities" do
+    custom_data_src_check = "#{FIXTURES_DIR}/images/srcset_picture_pixel-density.html"
+    proofer = run_proofer(custom_data_src_check, :file)
+    expect(proofer.failed_checks).to(eq([]))
+  end
+
+  it "breaks for picture elements with multiple srcsets and pixel densities" do
+    custom_data_src_check = "#{FIXTURES_DIR}/images/srcset_picture_pixel-density_broken.html"
+    proofer = run_proofer(custom_data_src_check, :file)
+    expect(proofer.failed_checks.first.description).to(match(/foo.webp does not exist/))
   end
 
   it "works for various webp images" do


### PR DESCRIPTION
As discussed in comments to #744 - this change shifts 'source' elements to be handled by the code path for checking images.

A number of other small changes to tests needed to be made also - this was because these tests were referring to non-existent images in tests that did not relate to the URL not being to a valid image. These have been updated to point to images that actually exist.