### PR TITLE
Lock to >= Ruby 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,10 @@
 name: Ruby CI
 
 on:
+  pull_request:
   push:
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -17,8 +20,6 @@ jobs:
       matrix:
         ruby-version:
           - 3.1.0
-          - 3.0.0
-          - 2.7.6
         experimental: [false]
         include:
           - ruby-version: head

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,10 +2,6 @@ name: Linting
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
-  push:
-    branches:
-      - main
 
 permissions:
   contents: read
@@ -17,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0
+          ruby-version: 3.1
           bundler-cache: true
       - run: bundle install
       - name: Rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,8 +8,17 @@ require:
 Naming/FileName:
   Enabled: false
 
+RSpec/AnyInstance:
+  Enabled: false
+
+RSpec/ExampleLength:
+  Enabled: false
+
 RSpec/FilePath:
   Enabled: false
 
 RSpec/MultipleExpectations:
+  Enabled: false
+
+RSpec/MultipleMemoizedHelpers:
   Enabled: false

--- a/html-proofer.gemspec
+++ b/html-proofer.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.bindir = "exe"
   spec.executables = ["htmlproofer"]
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = [">= 2.6.0", "< 4.0"]
+  spec.required_ruby_version = [">= 3.1", "< 4.0"]
 
   spec.metadata = {
     "funding_uri" => "https://github.com/sponsors/gjtorikian/",

--- a/lib/html_proofer/check/images.rb
+++ b/lib/html_proofer/check/images.rb
@@ -3,7 +3,7 @@
 module HTMLProofer
   class Check
     class Images < HTMLProofer::Check
-      SCREEN_SHOT_REGEX = /Screen(?: |%20)Shot(?: |%20)\d+-\d+-\d+(?: |%20)at(?: |%20)\d+.\d+.\d+/.freeze
+      SCREEN_SHOT_REGEX = /Screen(?: |%20)Shot(?: |%20)\d+-\d+-\d+(?: |%20)at(?: |%20)\d+.\d+.\d+/
 
       def run
         @html.css("img, source").each do |node|

--- a/spec/html-proofer/attribute/url_spec.rb
+++ b/spec/html-proofer/attribute/url_spec.rb
@@ -3,48 +3,46 @@
 require "spec_helper"
 
 describe HTMLProofer::Attribute::Url do
-  before(:each) do
-    @runner = HTMLProofer::Runner.new("")
-  end
+  let(:runner) { HTMLProofer::Runner.new("") }
 
   describe "#ignores_pattern_check" do
     it "works for regex patterns" do
-      @runner.options[:ignore_urls] = [%r{/assets/.*(js|css|png|svg)}]
-      url = HTMLProofer::Attribute::Url.new(@runner, "/assets/main.js")
-      expect(url.ignore?).to(eq(true))
+      runner.options[:ignore_urls] = [%r{/assets/.*(js|css|png|svg)}]
+      url = described_class.new(runner, "/assets/main.js")
+      expect(url.ignore?).to(be(true))
     end
 
     it "works for string patterns" do
-      @runner.options[:ignore_urls] = ["/assets/main.js"]
-      url = HTMLProofer::Attribute::Url.new(@runner, "/assets/main.js")
-      expect(url.ignore?).to(eq(true))
+      runner.options[:ignore_urls] = ["/assets/main.js"]
+      url = described_class.new(runner, "/assets/main.js")
+      expect(url.ignore?).to(be(true))
     end
   end
 
   describe "#protocol_relative" do
     it "works for protocol relative" do
-      url = HTMLProofer::Attribute::Url.new(@runner, "//assets/main.js")
-      expect(url.protocol_relative?).to(eq(true))
+      url = described_class.new(runner, "//assets/main.js")
+      expect(url.protocol_relative?).to(be(true))
     end
 
     it "works for https://" do
-      url = HTMLProofer::Attribute::Url.new(@runner, "https://assets/main.js")
-      expect(url.protocol_relative?).to(eq(false))
+      url = described_class.new(runner, "https://assets/main.js")
+      expect(url.protocol_relative?).to(be(false))
     end
 
     it "works for http://" do
-      url = HTMLProofer::Attribute::Url.new(@runner, "http://assets/main.js")
-      expect(url.protocol_relative?).to(eq(false))
+      url = described_class.new(runner, "http://assets/main.js")
+      expect(url.protocol_relative?).to(be(false))
     end
 
     it "works for relative internal link" do
-      url = HTMLProofer::Attribute::Url.new(@runner, "assets/main.js")
-      expect(url.protocol_relative?).to(eq(false))
+      url = described_class.new(runner, "assets/main.js")
+      expect(url.protocol_relative?).to(be(false))
     end
 
     it "works for absolute internal link" do
-      url = HTMLProofer::Attribute::Url.new(@runner, "/assets/main.js")
-      expect(url.protocol_relative?).to(eq(false))
+      url = described_class.new(runner, "/assets/main.js")
+      expect(url.protocol_relative?).to(be(false))
     end
   end
 end

--- a/spec/html-proofer/command_spec.rb
+++ b/spec/html-proofer/command_spec.rb
@@ -200,7 +200,7 @@ describe HTMLProofer::CLI do
     expect(output).to(match("successfully"))
   end
 
-  context "nested options" do
+  context "when including nested options" do
     it "supports typhoeus" do
       link_with_redirect_filepath = File.join(FIXTURES_DIR, "links", "link_with_redirect.html")
       output = make_bin(" --typhoeus '{ \"followlocation\": false }' #{link_with_redirect_filepath}")

--- a/spec/html-proofer/element_spec.rb
+++ b/spec/html-proofer/element_spec.rb
@@ -3,28 +3,25 @@
 require "spec_helper"
 
 describe HTMLProofer::Element do
-  before(:each) do
-    @runner = HTMLProofer::Runner.new("")
-    # @check = HTMLProofer::Check.new('', '', Nokogiri::HTML5(''), nil, nil, HTMLProofer::Configuration::PROOFER_DEFAULTS)
-  end
+  let(:runner) { HTMLProofer::Runner.new("") }
 
   describe "#initialize" do
     it "accepts the xmlns attribute" do
       nokogiri = Nokogiri::HTML5('<a xmlns:cc="http://creativecommons.org/ns#">Creative Commons</a>')
-      element = HTMLProofer::Element.new(@runner, nokogiri.css("a").first)
+      element = described_class.new(runner, nokogiri.css("a").first)
       expect(element.node["xmlns:cc"]).to(eq("http://creativecommons.org/ns#"))
     end
 
     it "assignes the text node" do
       nokogiri = Nokogiri::HTML5("<p>One")
-      element = HTMLProofer::Element.new(@runner, nokogiri.css("p").first)
+      element = described_class.new(runner, nokogiri.css("p").first)
       expect(element.node.text).to(eq("One"))
       expect(element.node.content).to(eq("One"))
     end
 
     it "accepts the content attribute" do
       nokogiri = Nokogiri::HTML5('<meta name="twitter:card" content="summary">')
-      element = HTMLProofer::Element.new(@runner, nokogiri.css("meta").first)
+      element = described_class.new(runner, nokogiri.css("meta").first)
       expect(element.node["content"]).to(eq("summary"))
     end
   end
@@ -32,7 +29,7 @@ describe HTMLProofer::Element do
   describe "#link_attribute" do
     it "works for src attributes" do
       nokogiri = Nokogiri::HTML5("<img src=image.png />")
-      element = HTMLProofer::Element.new(@runner, nokogiri.css("img").first)
+      element = described_class.new(runner, nokogiri.css("img").first)
       expect(element.url.to_s).to(eq("image.png"))
     end
   end
@@ -40,8 +37,8 @@ describe HTMLProofer::Element do
   describe "#ignore" do
     it "works for twitter cards" do
       nokogiri = Nokogiri::HTML5('<meta name="twitter:url" data-proofer-ignore content="http://example.com/soon-to-be-published-url">')
-      element = HTMLProofer::Element.new(@runner, nokogiri.css("meta").first)
-      expect(element.ignore?).to(eq(true))
+      element = described_class.new(runner, nokogiri.css("meta").first)
+      expect(element.ignore?).to(be(true))
     end
   end
 

--- a/spec/html-proofer/favicon_spec.rb
+++ b/spec/html-proofer/favicon_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "Favicons test" do
+describe HTMLProofer::Check::Favicon do
   it "ignores for absent favicon by default" do
     absent = File.join(FIXTURES_DIR, "favicon", "favicon_absent.html")
     expect(run_proofer(absent, :file).failed_checks).to(eq([]))

--- a/spec/html-proofer/images_spec.rb
+++ b/spec/html-proofer/images_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "Images test" do
+describe HTMLProofer::Check::Images do
   it "passes for existing external images" do
     external_image_filepath = File.join(FIXTURES_DIR, "images", "existing_image_external.html")
     proofer = run_proofer(external_image_filepath, :file)
@@ -134,13 +134,13 @@ describe "Images test" do
     expect(proofer.failed_checks).to(eq([]))
   end
 
-  it "properly ignores missing alt tags when asked" do
+  it "properly ignores urls when asked" do
     ignoreable_links = File.join(FIXTURES_DIR, "images", "ignorable_alt_via_options.html")
     proofer = run_proofer(ignoreable_links, :file, ignore_urls: [/wikimedia/, "gpl.png"])
     expect(proofer.failed_checks).to(eq([]))
   end
 
-  it "properly ignores missing alt tags when asked" do
+  it "properly ignores missing urls when asked" do
     ignoreable_links = File.join(FIXTURES_DIR, "images", "ignore_alt_but_not_link.html")
     proofer = run_proofer(ignoreable_links, :file, ignore_urls: [/.*/])
     expect(proofer.failed_checks).to(eq([]))

--- a/spec/html-proofer/links_spec.rb
+++ b/spec/html-proofer/links_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "Links test" do
+describe HTMLProofer::Check::Links do
   it "fails for broken internal hash (even if the file exists)" do
     broken_hash_external_filepath = File.join(FIXTURES_DIR, "links", "broken_hash_external_file.html")
     proofer = run_proofer(broken_hash_external_filepath, :file)
@@ -136,7 +136,7 @@ describe "Links test" do
     expect(proofer.failed_checks).to(eq([]))
   end
 
-  it "should follow redirects" do
+  it "follows redirects" do
     link_with_redirect_filepath = File.join(FIXTURES_DIR, "links", "link_with_redirect.html")
     proofer = run_proofer(link_with_redirect_filepath, :file, { enforce_https: false })
     expect(proofer.failed_checks).to(eq([]))
@@ -157,7 +157,7 @@ describe "Links test" do
     expect(proofer.failed_checks).to(eq([]))
   end
 
-  it "should understand https" do
+  it "understands https" do
     link_with_https_filepath = File.join(FIXTURES_DIR, "links", "link_with_https.html")
     proofer = run_proofer(link_with_https_filepath, :file)
     expect(proofer.failed_checks).to(eq([]))
@@ -169,7 +169,7 @@ describe "Links test" do
     expect(proofer.failed_checks.first.description).to(match(/internally linking to #25-method-not-allowed; the file exists, but the hash '25-method-not-allowed' does not/))
   end
 
-  it "should understand relative hash" do
+  it "understands relative hash" do
     link_with_https_filepath = File.join(FIXTURES_DIR, "links", "relative_hash.html")
     proofer = run_proofer(link_with_https_filepath, :file)
     expect(proofer.failed_checks).to(eq([]))
@@ -485,20 +485,18 @@ describe "Links test" do
     expect(proofer.failed_checks).to(eq([]))
   end
 
-  context "automatically adding default extensions to files" do
-    before :each do
-      @fixture = File.join(FIXTURES_DIR, "links", "no_html_extension.html")
-    end
+  context "when automatically adding default extensions to files" do
+    let(:fixture) { File.join(FIXTURES_DIR, "links", "no_html_extension.html") }
 
     it "can be turned off" do
       # Default behaviour does not change
-      proofer = run_proofer(@fixture, :file, { assume_extension: "" })
+      proofer = run_proofer(fixture, :file, { assume_extension: "" })
       expect(proofer.failed_checks.count).to(be >= 3)
     end
 
     it "accepts extensionless file links by default" do
       # With command-line option
-      proofer = run_proofer(@fixture, :file)
+      proofer = run_proofer(fixture, :file)
       expect(proofer.failed_checks).to(eq([]))
     end
   end
@@ -741,7 +739,7 @@ describe "Links test" do
     expect(proofer.failed_checks.first.description).to(match(/is an invalid URL/))
   end
 
-  it "should not try reading PDFs" do
+  it "does not try reading PDFs" do
     file = File.join(FIXTURES_DIR, "links", "pdfs.html")
     proofer = run_proofer(file, :file)
     expect(proofer.failed_checks.count).to(eq(3))

--- a/spec/html-proofer/maliciousness_spec.rb
+++ b/spec/html-proofer/maliciousness_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "Maliciousness test" do
+describe "Maliciousness test" do # rubocop:disable RSpec/DescribeClass
   it "does not accept non-string input for single file" do
     expect do
       run_proofer(23, :file)

--- a/spec/html-proofer/opengraph_spec.rb
+++ b/spec/html-proofer/opengraph_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "Open Graph test" do
+describe HTMLProofer::Check::OpenGraph do
   it "passes for existing external url" do
     url_valid = File.join(FIXTURES_DIR, "opengraph", "url-valid.html")
     proofer = run_proofer(url_valid, :file, checks: ["OpenGraph"])

--- a/spec/html-proofer/parse_json_option_spec.rb
+++ b/spec/html-proofer/parse_json_option_spec.rb
@@ -3,58 +3,58 @@
 require "spec_helper"
 require "html-proofer"
 
-describe "JSON config parser" do
+describe HTMLProofer::Configuration do
   it "Throws an error when the option name is not a string" do
     expect do
-      HTMLProofer::Configuration.new.parse_json_option(123,
+      described_class.new.parse_json_option(123,
         "")
     end.to(raise_error(ArgumentError, "Must provide an option name in string format."))
   end
 
   it "Throws an error when the option name is empty" do
     expect do
-      HTMLProofer::Configuration.new.parse_json_option("",
+      described_class.new.parse_json_option("",
         "{}")
     end.to(raise_error(ArgumentError, "Must provide an option name in string format."))
   end
 
   it "Throws an error when the option name is whitespace" do
     expect do
-      HTMLProofer::Configuration.new.parse_json_option("    ",
+      described_class.new.parse_json_option("    ",
         "{}")
     end.to(raise_error(ArgumentError, "Must provide an option name in string format."))
   end
 
   it "Throws an error when the json config is not a string" do
     expect do
-      HTMLProofer::Configuration.new.parse_json_option("testName",
+      described_class.new.parse_json_option("testName",
         123)
     end.to(raise_error(ArgumentError, "Must provide a JSON configuration in string format."))
   end
 
   it "returns an empty options object when config is nil" do
-    result = HTMLProofer::Configuration.new.parse_json_option("testName", nil)
+    result = described_class.new.parse_json_option("testName", nil)
     expect(result).to(eq({}))
   end
 
   it "returns an empty options object when config is empty" do
-    result = HTMLProofer::Configuration.new.parse_json_option("testName", "")
+    result = described_class.new.parse_json_option("testName", "")
     expect(result).to(eq({}))
   end
 
   it "returns an empty options object when config is whitespace" do
-    result = HTMLProofer::Configuration.new.parse_json_option("testName", "    ")
+    result = described_class.new.parse_json_option("testName", "    ")
     expect(result).to(eq({}))
   end
 
   it "Returns an object representing the json when valid json" do
-    result = HTMLProofer::Configuration.new.parse_json_option("testName",
+    result = described_class.new.parse_json_option("testName",
       '{ "myValue": "hello world!", "numberValue": 123}')
     expect(result[:myValue]).to(eq("hello world!"))
     expect(result[:numberValue]).to(eq(123))
   end
 
   it "Throws an error when the json config is not valid json" do
-    expect { HTMLProofer::Configuration.new.parse_json_option("testName", "abc") }.to(raise_error(ArgumentError))
+    expect { described_class.new.parse_json_option("testName", "abc") }.to(raise_error(ArgumentError))
   end
 end

--- a/spec/html-proofer/proofer_spec.rb
+++ b/spec/html-proofer/proofer_spec.rb
@@ -18,7 +18,7 @@ describe HTMLProofer do
   describe "#files" do
     it "works for directory that ends with .html" do
       folder = File.join(FIXTURES_DIR, "links", "_site/folder.html")
-      proofer = HTMLProofer.check_directory(folder)
+      proofer = described_class.check_directory(folder)
       expect(proofer.files).to(eq([{ source: folder, path: "#{folder}/index.html" }]))
     end
   end
@@ -26,14 +26,14 @@ describe HTMLProofer do
   describe "#options" do
     it "strips out undesired Typhoeus options" do
       folder = File.join(FIXTURES_DIR, "links", "_site/folder.html")
-      proofer = HTMLProofer.check_file(folder, verbose: true)
+      proofer = described_class.check_file(folder, verbose: true)
       expect(proofer.options[:verbose]).to(be(true))
       expect(proofer.options[:typhoeus][:verbose]).to(be_nil)
     end
 
     it "takes options for Parallel" do
       folder = File.join(FIXTURES_DIR, "links", "_site/folder.html")
-      proofer = HTMLProofer.check_file(folder, parallel: { in_processes: 3 })
+      proofer = described_class.check_file(folder, parallel: { in_processes: 3 })
       expect(proofer.options[:parallel][:in_processes]).to(eq(3))
       expect(proofer.options[:typhoeus][:in_processes]).to(be_nil)
     end

--- a/spec/html-proofer/scripts_spec.rb
+++ b/spec/html-proofer/scripts_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "Scripts test" do
+describe HTMLProofer::Check::Scripts do
   it "fails for src missing the protocol" do
     file = File.join(FIXTURES_DIR, "scripts", "script_missing_protocol.html")
     proofer = run_proofer(file, :file)

--- a/spec/html-proofer/utils_spec.rb
+++ b/spec/html-proofer/utils_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 describe HTMLProofer::Utils do
   describe "::create_nokogiri" do
-    include HTMLProofer::Utils
+    include described_class
 
     it "passes for a string" do
       noko = create_nokogiri('<html lang="jp">')


### PR DESCRIPTION
Ruby 3.1 has some optimizations for Windows; since I'm breaking a new major release out, it makes sense to lift the restrictions here a bit. Plus, I want to use `async` instead of `parallel`, which is a Ruby 3+ addition.