### PR TITLE
Check utf8 relative anchors

### DIFF
--- a/spec/html-proofer/check/links_spec.rb
+++ b/spec/html-proofer/check/links_spec.rb
@@ -46,9 +46,9 @@ describe "Check::Links" do
     expect(proofer.failed_checks.first.description).to(match(/internally linking to #noHash; the file exists, but the hash 'noHash' does not/))
   end
 
-  it "passes for internal links with non-ASCII characters" do
-    broken_hash_internal_filepath = File.join(FIXTURES_DIR, "links", "hash_nonascii.html")
-    proofer = run_proofer(broken_hash_internal_filepath, :file)
+  it "passes for internal links with non-ASCII characters from implicit indexes" do
+    broken_hash_internal_filepath = File.join(FIXTURES_DIR, "links", "hash_nonascii_dir")
+    proofer = run_proofer(broken_hash_internal_filepath, :directory, check_internal_hash: true)
     expect(proofer.failed_checks).to(eq([]))
   end      
 

--- a/spec/html-proofer/check/links_spec.rb
+++ b/spec/html-proofer/check/links_spec.rb
@@ -46,6 +46,12 @@ describe "Check::Links" do
     expect(proofer.failed_checks.first.description).to(match(/internally linking to #noHash; the file exists, but the hash 'noHash' does not/))
   end
 
+  it "passes for internal links with non-ASCII characters" do
+    broken_hash_internal_filepath = File.join(FIXTURES_DIR, "links", "hash_nonascii.html")
+    proofer = run_proofer(broken_hash_internal_filepath, :file)
+    expect(proofer.failed_checks).to(eq([]))
+  end      
+
   it "passes for broken internal hash when asked to ignore" do
     broken_hash_internal_filepath = File.join(FIXTURES_DIR, "links", "broken_hash_internal.html")
     proofer = run_proofer(broken_hash_internal_filepath, :file, check_internal_hash: false)

--- a/spec/html-proofer/check/links_spec.rb
+++ b/spec/html-proofer/check/links_spec.rb
@@ -50,7 +50,7 @@ describe "Check::Links" do
     broken_hash_internal_filepath = File.join(FIXTURES_DIR, "links", "hash_nonascii_dir")
     proofer = run_proofer(broken_hash_internal_filepath, :directory, check_internal_hash: true)
     expect(proofer.failed_checks).to(eq([]))
-  end      
+  end
 
   it "passes for broken internal hash when asked to ignore" do
     broken_hash_internal_filepath = File.join(FIXTURES_DIR, "links", "broken_hash_internal.html")

--- a/spec/html-proofer/fixtures/links/hash_nonascii.html
+++ b/spec/html-proofer/fixtures/links/hash_nonascii.html
@@ -1,0 +1,8 @@
+<html>
+  <body>
+    <p>Blah blah blah. <a href="#eigentümerschaft">Hash mit ein umlaut</a></p>
+
+    <h2 id="eigentümerschaft">Hier gib's</h2>
+  </body>
+</html>
+

--- a/spec/html-proofer/fixtures/links/hash_nonascii_dir/source/index.html
+++ b/spec/html-proofer/fixtures/links/hash_nonascii_dir/source/index.html
@@ -1,0 +1,8 @@
+<html>
+  <body>
+    <p><a href="../target/#eigentümerschaft">Hash mit ein umlaut</a></p>
+    <p><a href="../target/#mitarbeit">Hash ohne ein umlaut</a></p>
+
+  </body>
+</html>
+

--- a/spec/html-proofer/fixtures/links/hash_nonascii_dir/target/index.html
+++ b/spec/html-proofer/fixtures/links/hash_nonascii_dir/target/index.html
@@ -1,8 +1,10 @@
 <html>
   <body>
-    <p>Blah blah blah. <a href="#eigentümerschaft">Hash mit ein umlaut</a></p>
-
     <h2 id="eigentümerschaft">Hier gib's</h2>
+
+    blah de blah
+
+    <h2 id="mitarbeit">Hier auch</h2>
   </body>
 </html>
 


### PR DESCRIPTION
This adds a test for the false-negative failures seen in https://github.com/gjtorikian/html-proofer/issues/757 - the root cause was an interaction between the (now-removed) regexp in the `clean_url!` method and Addressable::URI's `normalize`. The test passes now that https://github.com/gjtorikian/html-proofer/pull/820 is merged but the test should prevent regressions in the future.