### PR TITLE
Add `benchmark` to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,4 +18,4 @@ gem "rubocop"
 gem "rubocop-rspec"
 gem "rubocop-standard"
 
-gem "benchmark", "~> 0.5.0"
+gem "benchmark", "~> 0.5"


### PR DESCRIPTION
The `benchmark` gem has been extracted from the Ruby standard library, and will soon be removed from the Ruby standard library.

This solves the following test failure:

```
  1) Reporter::Terminal report reports as-links accurately
     Failure/Error: expect(output).to(match(msg))

       expected "Running 1 check (LinkCheck) on [\"www.github.com\", \"http://asdadsadsasdadaf.biz/\"] ...\n\n\nCheck... too many requests at once also breaks things. (status code 0)\n\n\nHTML-Proofer found 1 failure!\n" to match "Running 1 check (LinkCheck) on [\"www.github.com\", \"http://asdadsadsasdadaf.biz/\"] ...\n\n\nChecking 2 external links\n\nFor the Links > External check, the following failures were found:\n\n* External link http://asdadsadsasdadaf.biz/ failed with something very wrong.\nIt's possible libcurl couldn't connect to the server, or perhaps the request timed out.\nSometimes, making too many requests at once also breaks things. (status code 0)\n\n\nHTML-Proofer found 1 failure!\n"
       Diff:
       @@ -3,6 +3,8 @@

        Checking 2 external links

       +exe/htmlproofer:9: warning: benchmark was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
       +You can add benchmark to your Gemfile or gemspec to silence this warning.
        For the Links > External check, the following failures were found:

        * External link http://asdadsadsasdadaf.biz/ failed with something very wrong.

     # ./spec/html-proofer/reporter/terminal_spec.rb:104:in 'block (3 levels) in <top (required)>'
```